### PR TITLE
Fix root-owned ~/.vibe and opaque daemon-start errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ local.vibe — a local DNS daemon that gives dev servers friendly `.vibe` names.
 
 - **Never commit unless the user explicitly asks.** Do not auto-commit after completing a task or bundle commits into other actions.
 - **Always run `vibe dev` after changes** to rebuild and restart the daemon.
+- **Tests must pass before declaring a task done or pushing.** Run `go build ./... && go vet ./... && go test ./...` after any change. If a test fails — even one that looks unrelated or flaky — investigate before continuing. Do not push or open PRs over a red test suite. If a failure is genuinely flaky, re-run a few times; if it reproduces, fix it or call it out explicitly to the user before moving on.
+- **Check CI on `main` periodically.** If CI is red on `main`, the next change should fix it before adding new work — don't keep stacking commits on a broken pipeline.
 
 ## Build & test
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -68,11 +68,18 @@ var daemonStartCmd = &cobra.Command{
 				if isDaemonRunning() {
 					pid, _ := readDaemonPID()
 					fmt.Printf("daemon started (pid %d)\n", pid)
+					if warn := scanDaemonLogForWarnings(); warn != "" {
+						fmt.Fprintln(os.Stderr, warn)
+					}
 					openDashboard()
 					return nil
 				}
 			}
-			return fmt.Errorf("daemon did not start — check %s", filepath.Join(config.Dir(), "daemon.log"))
+			logPath := filepath.Join(config.Dir(), "daemon.log")
+			if tail := tailFile(logPath, 20); tail != "" {
+				return fmt.Errorf("daemon did not start — last lines of %s:\n%s", logPath, tail)
+			}
+			return fmt.Errorf("daemon did not start — check %s", logPath)
 		}
 
 		// Fallback: fork-based start
@@ -171,7 +178,43 @@ func forkDaemon() error {
 			return nil
 		}
 	}
+	if tail := tailFile(logPath, 20); tail != "" {
+		return fmt.Errorf("daemon did not start — last lines of %s:\n%s", logPath, tail)
+	}
 	return fmt.Errorf("daemon did not start — check %s", logPath)
+}
+
+// tailFile returns the last n lines of the file at path, or "" if unreadable.
+func tailFile(path string, n int) string {
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// scanDaemonLogForWarnings returns a single-line summary of any "warning:"
+// lines in the recent tail of the daemon log, or "" if none. Used to surface
+// degraded-mode warnings (e.g. HTTPS bind failure) on a successful start.
+func scanDaemonLogForWarnings() string {
+	tail := tailFile(filepath.Join(config.Dir(), "daemon.log"), 30)
+	if tail == "" {
+		return ""
+	}
+	var warns []string
+	for _, line := range strings.Split(tail, "\n") {
+		if strings.Contains(line, "warning:") {
+			warns = append(warns, strings.TrimSpace(line))
+		}
+	}
+	if len(warns) == 0 {
+		return ""
+	}
+	return strings.Join(warns, "\n")
 }
 
 func readDaemonPID() (int, error) {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -368,7 +368,17 @@ func verifyDNS() error {
 
 func generateCerts() error {
 	home, _ := realUserHome()
-	certsDir := filepath.Join(home, ".vibe", "certs")
+	vibeDir := filepath.Join(home, ".vibe")
+	certsDir := filepath.Join(vibeDir, "certs")
+
+	// Ensure ~/.vibe/ exists and is owned by the real user before any cert
+	// work. Without this, cert.EnsureCA's MkdirAll creates ~/.vibe/ as root,
+	// and the user-mode daemon (LaunchAgent) later can't write daemon.pid,
+	// daemon.log, or the unix socket. See issues #2 and #5.
+	if err := os.MkdirAll(vibeDir, 0755); err != nil {
+		return fmt.Errorf("create %s: %w", vibeDir, err)
+	}
+	chownToUser(vibeDir)
 
 	caCert, caKey, err := cert.EnsureCA(certsDir)
 	if err != nil {

--- a/internal/cert/cert_test.go
+++ b/internal/cert/cert_test.go
@@ -1,6 +1,7 @@
 package cert
 
 import (
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -297,7 +298,7 @@ func writeExpiringCert(t *testing.T, dir string, ca *x509.Certificate, caKey int
 	keyBlock, _ := pem.Decode(keyData)
 	leafKey, _ := x509.ParseECPrivateKey(keyBlock.Bytes)
 
-	certDER, err := x509.CreateCertificate(nil, template, ca, &leafKey.PublicKey, caKey)
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca, &leafKey.PublicKey, caKey)
 	if err != nil {
 		t.Fatalf("create expiring cert: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Setup now creates and chowns `~/.vibe/` to the real user before any cert work, so the user-mode LaunchAgent can write `daemon.pid`, `daemon.log`, and the unix socket after `sudo vibe setup`.
- `vibe daemon start` now tails `daemon.log` into its "did not start" error and surfaces any `warning:` lines on successful start, so HTTPS-bind failures and other degraded-mode boots are visible instead of opaque.

Fixes #2
Fixes #5

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (pre-existing flaky `TestProcessStartEarlyCrashDetection` unrelated)
- [ ] Manual: `sudo vibe setup` on a fresh machine → confirm `ls -ld ~/.vibe` shows real user, daemon starts cleanly
- [ ] Manual: hold port 7443 with another process → run `vibe daemon start` → confirm CLI prints HTTPS warning instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)