### PR TITLE
OAuth localhost callback bridge + managed-route reliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ The daemon runs a compiled binary at `/opt/homebrew/bin/vibe`, not source — ch
    - `log_scan.go` — regex patterns for extracting recovery hints (orphan PID, EADDRINUSE) from failed process log tails
    - `port_discover.go` — finds a managed route's real listening port via `lsof` on the process group and log-tail regex
    - `proxy_bookmark.go` — reverse-proxy for bookmark routes with `proxy=true` (landing path redirect, Location/cookie rewrites, X-Forwarded-For suppression)
+   - `oauth_bridge.go` — per-route localhost OAuth callback listeners (see `oauth_callback_port`); 307-forward `?code=...` from `localhost:N` to `https://name.vibe/...` so OAuth providers that require a localhost redirect URI work without leaving the .vibe origin
    - `theme.go` — Shared CSS/HTML head (Geist fonts, Vercel-inspired dark theme)
    - `setup_md.go` — Markdown setup guide served at `/setup.md`
 
@@ -56,7 +57,7 @@ Five route types with different lifecycle semantics:
 - **sticky** — `vibe register`; persists across daemon restarts; reverse-proxied
 - **pid** — API only; auto-removed when tracked PID dies
 - **ttl** — `--ttl` flag on register; auto-expires after N seconds
-- **managed** — `vibe start` (reads `vibe.json` or inline args); daemon manages the child process, dashboard has start/stop buttons. Port can be omitted for auto-assignment.
+- **managed** — `vibe start` (reads `vibe.json` or inline args); daemon manages the child process, dashboard has start/stop buttons. Port can be omitted for auto-assignment. Optional fields: `oauth_callback_port` (binds a localhost listener that 307-forwards to the .vibe URL — for OAuth providers that require a localhost redirect URI), `reserve_ports` (`{"name": port}` map of auxiliary ports the cmd also binds; reserved across the route table to prevent collisions, exposed to the child as `PORT_<UPPER_NAME>` env vars), `idle_timeout` (minutes; 0 = never auto-stop).
 - **bookmark** — External URL (e.g. Tailscale address); persists across restarts; visiting `name.vibe` either 307-redirects to the external URL or reverse-proxies to it (per-route `proxy` flag). Added/edited via dashboard modal.
 
 ## Key patterns
@@ -76,6 +77,7 @@ Five route types with different lifecycle semantics:
 - **Embedded UI:** All HTML/CSS/JS is inline Go strings — no external assets, no build step. Dashboard includes a modal for CRUD operations on routes. Toast notifications surface errors from async actions.
 - **TLS hot-reload:** Daemon holds a `sync.RWMutex`-guarded `*tls.Certificate` served via `GetCertificate`. When routes change (`saveStickyRoutes`), the leaf cert is regenerated with updated SANs and atomically swapped — no restart needed. The CA (10-year, trusted in Keychain) stays fixed; only the leaf (825-day) rotates.
 - **Managed-route self-healing:** When a route's registered port stops answering, `routeRequest` serves the repair page (or the start page when the child is gone). `port_discover.go` tries `lsof` on the process group and a log-tail regex to find the real listening port; `RouteTable.UpdatePort` atomically rewrites the registration so subsequent requests proxy correctly. Start failures attach a tailed log + recovery hint (orphan PID, EADDRINUSE) via `StartError` → `Failure`; the start page surfaces a one-click "Kill PID X and Retry" button, and `safeKillPID` refuses to signal the daemon itself or other managed routes.
+- **Browser-form vs JSON requests:** Some `/_api/routes/*` handlers (`handleStart`, `handleStop`, etc.) 303-redirect back to the dashboard when the request looks like a browser HTML form post — detected via `isBrowserFormRequest` (Content-Type `application/x-www-form-urlencoded`). The CLI client sends `Accept: application/json` and gets the JSON response directly. Don't gate the redirect on the `Accept` header alone: a missing Accept used to be misclassified as a browser request, and the resulting 303 to `https://local.vibe/` killed the CLI when followed over the Unix-socket transport (TLS over unix conn fails, surfaced as a spurious "daemon not running").
 - **Bookmark proxy mode:** When a bookmark has `proxy=true`, `proxyBookmark` reverse-proxies to the upstream instead of 307-redirecting. The upstream `Host` header is forced to the external URL's host (SNI/vhost correctness). Same-origin 3xx `Location` headers are rewritten to the `.vibe` host, `Domain=` is stripped from `Set-Cookie` so browsers actually store cookies, and `X-Forwarded-For` is suppressed (strict upstreams like Home Assistant return 400 when they see it). The bookmark URL's path is treated as a landing destination: requests to `name.vibe/` 302 once to the path, but everything else passes through at the origin so SPA assets loaded from `/` resolve correctly. Optional per-route `insecure_skip_verify` disables upstream TLS verification for self-signed targets (Tailscale MagicDNS, etc.).
 
 ## System setup (macOS)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ The daemon runs a compiled binary at `/opt/homebrew/bin/vibe`, not source — ch
    - `log_scan.go` — regex patterns for extracting recovery hints (orphan PID, EADDRINUSE) from failed process log tails
    - `port_discover.go` — finds a managed route's real listening port via `lsof` on the process group and log-tail regex
    - `proxy_bookmark.go` — reverse-proxy for bookmark routes with `proxy=true` (landing path redirect, Location/cookie rewrites, X-Forwarded-For suppression)
+   - `sync_config.go` — re-reads `vibe.json` from a managed route's `Dir` on each `Start` so edits to `cmd`, `oauth_callback_port`, or `reserve_ports` take effect without re-registering
    - `oauth_bridge.go` — per-route localhost OAuth callback listeners (see `oauth_callback_port`); 307-forward `?code=...` from `localhost:N` to `https://name.vibe/...` so OAuth providers that require a localhost redirect URI work without leaving the .vibe origin
    - `theme.go` — Shared CSS/HTML head (Geist fonts, Vercel-inspired dark theme)
    - `setup_md.go` — Markdown setup guide served at `/setup.md`

--- a/FUTURE_PLAN.md
+++ b/FUTURE_PLAN.md
@@ -1,0 +1,87 @@
+# Future: Windows & Linux Support
+
+local.vibe is currently macOS-only. This document captures what would need to change to support Windows and Linux.
+
+---
+
+## Areas Requiring Platform-Specific Work
+
+### 1. DNS Resolution
+
+| | macOS (done) | Linux | Windows |
+|---|---|---|---|
+| **Mechanism** | `/etc/resolver/vibe` | dnsmasq or systemd-resolved | Acrylic DNS Proxy or embedded Go DNS server |
+
+Windows has no `/etc/resolver/` equivalent. Options: third-party Acrylic DNS Proxy, or a lightweight Go DNS stub on 127.0.0.1:53 that handles `.vibe` queries locally.
+
+### 2. Port 80 Forwarding
+
+| | macOS (done) | Linux | Windows |
+|---|---|---|---|
+| **Mechanism** | pf (`pfctl`) | iptables/nftables NAT REDIRECT | `netsh interface portproxy` |
+
+### 3. Daemon Lifecycle (autostart + keep-alive)
+
+| | macOS (done) | Linux | Windows |
+|---|---|---|---|
+| **Mechanism** | LaunchAgent + `launchctl` | systemd user service | Windows Service (`golang.org/x/sys/windows/svc`) |
+
+### 4. Process Management
+
+macOS/Linux use POSIX process groups (`Setpgid`, `Kill(-pgid, SIGTERM)`). Windows has no equivalent — would need Job Objects (`windows.CreateJobObject`) via build-tagged files:
+
+```
+internal/daemon/process_unix.go      // +build !windows
+internal/daemon/process_windows.go   // +build windows
+cmd/setup_darwin.go
+cmd/setup_linux.go
+cmd/setup_windows.go
+```
+
+### 5. Shell Execution
+
+Currently uses `$SHELL -lic` (defaults to `/bin/zsh`). Windows would use `cmd.exe /C` or `powershell.exe -Command`.
+
+### 6. Unix Socket
+
+Unix sockets don't exist on Windows. Recommend TCP-only on Windows (fallback already exists).
+
+### 7. Paths and Defaults
+
+| | macOS | Linux | Windows |
+|---|---|---|---|
+| Binary | `/opt/homebrew/bin/vibe` | `/usr/local/bin/vibe` | `%LOCALAPPDATA%\vibe\vibe.exe` |
+| Config | `~/.vibe/` | `~/.vibe/` or `$XDG_CONFIG_HOME/vibe/` | `%APPDATA%\vibe\` |
+
+Use `os.UserConfigDir()` to abstract paths.
+
+### 8. CI
+
+Add build matrix: `macos-latest`, `ubuntu-latest`, `windows-latest`.
+
+### 9. New Dependencies (Windows only)
+
+- `golang.org/x/sys/windows/svc` — Windows Service management
+- `golang.org/x/sys/windows` — Job Objects for process groups
+
+---
+
+## Recommended Implementation Order
+
+1. **Refactor process management with build tags** — split into unix/windows variants
+2. **Automate Linux setup** — stub already exists in `cmd/setup.go`
+3. **CI matrix** — catch cross-platform issues early
+4. **Abstract paths** — `os.UserConfigDir()`, remove hardcoded Homebrew paths
+5. **Windows daemon** — service registration, TCP-only communication
+6. **Windows DNS + port forwarding** — embedded DNS or Acrylic, netsh portproxy
+7. **Windows process groups** — Job Objects
+
+## Complexity
+
+| Area | Effort |
+|---|---|
+| Linux automated setup | Low (stub exists) |
+| Process management refactor | Medium |
+| CI matrix | Low |
+| Path abstraction | Low |
+| Windows support (full) | High |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ vibe start                           # Start from vibe.json in the current dir
 vibe start myapp                     # Start an already-registered route
 vibe start myapp 3000 -- npm run dev # Register + start inline
 vibe stop myapp                      # Stop a managed app
+vibe restart myapp                   # Stop + start (picks up vibe.json edits)
 vibe register myapp 3000             # Static mapping (no process management)
 vibe deregister myapp                # Remove a route
 vibe list                            # List all routes

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ vibe dev                             # Rebuild + restart daemon (for contributor
 | `cmd` | yes | Shell command to start the app |
 | `icon` | no | Emoji or image URL for the dashboard |
 | `idle_timeout` | no | Auto-stop after N minutes of no traffic (0 = never) |
+| `oauth_callback_port` | no | Fixed localhost port for OAuth callbacks |
+| `reserve_ports` | no | `{"name": port}` map of auxiliary ports the cmd binds; injected as `$PORT_<UPPER_NAME>` (see [setup.md](internal/daemon/setup.md#apps-that-bind-more-than-one-port)) |
 
 **Tip:** use `python3` (not `python`) on macOS. For Python apps, prefer a venv: `".venv/bin/python app.py"`.
 

--- a/TODO_OAUTH_REDIRECT.md
+++ b/TODO_OAUTH_REDIRECT.md
@@ -35,6 +35,13 @@ This branch adds `oauth_callback_port` and a localhost callback bridge for OAuth
 - [ ] Verify no regressions for routes without `oauth_callback_port`.
 - [ ] Verify bookmark/proxy route behavior remains unchanged.
 
+### 6a) Gaps found during tasks.vibe setup (2026-04-23)
+- [ ] `vibe start` on an already-registered route (`startExisting` path) silently ignores `oauth_callback_port` changes in `vibe.json`. Should re-sync `oauth_callback_port` (and likely `icon`, `idle_timeout`) from disk when re-starting. Currently the field only gets applied on first-time register — if the user adds it after registration, subsequent `vibe start` does nothing with it.
+- [ ] `validateOAuthBridgeConfig` doesn't detect collisions between a callback port and *another route's app port* (e.g. callback 3000 while another managed route has `port: 3000`). Desired behavior:
+    - Other route **not running** → warn (log + dashboard badge), allow.
+    - Other route **running** → error (reject at register/update time; also refuse to start a colliding route later, surfaced on the start page).
+- [x] Callback path was hardcoded to `/auth/google/callback`; NextAuth's `/api/auth/callback/google` 404'd. Fixed by forwarding any path to the route's `.{{TLD}}` host.
+
 ### 7) Cleanup before merge
 - [ ] Remove this TODO file.
 - [ ] Squash/fix commit messages as needed.

--- a/TODO_OAUTH_REDIRECT.md
+++ b/TODO_OAUTH_REDIRECT.md
@@ -1,0 +1,41 @@
+# TODO: OAuth localhost callback bridge hardening (delete before merge)
+
+This branch adds `oauth_callback_port` and a localhost callback bridge for OAuth flows that must return to `http://localhost:<port>/auth/google/callback`.
+
+## Ship readiness checklist
+
+### 1) Product / behavior
+- [ ] Decide if callback path should stay hardcoded (`/auth/google/callback`) or become configurable per route.
+- [ ] Decide if bridge should support providers beyond Google by allowing multiple callback paths.
+- [ ] Document exact route semantics for managed apps using bridge mode.
+
+### 2) API / config
+- [ ] Add docs for `oauth_callback_port` in README and setup docs.
+- [ ] Confirm dashboard route CRUD surfaces `oauth_callback_port` (or intentionally hide it as advanced-only).
+- [ ] Ensure API update semantics can clear `oauth_callback_port` explicitly (nullable behavior).
+
+### 3) Runtime correctness
+- [ ] Add tests for daemon restart + persisted bridge listener recovery.
+- [ ] Add tests for update flows (change callback port, remove callback port, route rename).
+- [ ] Add tests for conflict handling when another process binds callback port after route registration.
+- [ ] Verify clean listener teardown on route deregister and daemon shutdown.
+
+### 4) Security review
+- [ ] Validate that bridge only redirects to known route host derived from route table (no user-controlled host).
+- [ ] Audit open-redirect risk in callback bridge (query passthrough is expected; host must remain fixed).
+- [ ] Re-check interaction with TLS redirect behavior and non-TLS mode.
+
+### 5) UX / operability
+- [ ] Improve error messages when callback bridge is missing/unavailable (currently looks like localhost connection failure in browser).
+- [ ] Add a health/debug endpoint for active oauth bridge listeners.
+- [ ] Consider status output to display `oauth_callback_port` for managed routes.
+
+### 6) Regression control
+- [ ] Add integration-style tests that model Screener-like split frontend/backend dev server behavior.
+- [ ] Verify no regressions for routes without `oauth_callback_port`.
+- [ ] Verify bookmark/proxy route behavior remains unchanged.
+
+### 7) Cleanup before merge
+- [ ] Remove this TODO file.
+- [ ] Squash/fix commit messages as needed.
+- [ ] Re-run: `go test ./...` and `vibe dev` on final branch state.

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/graiz/local.vibe/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var restartCmd = &cobra.Command{
+	Use:   "restart <name>",
+	Short: "Stop and start a managed app",
+	Long: `Stop a managed app and start it again. Equivalent to:
+
+  vibe stop <name> && vibe start <name>
+
+Useful when reloading code that survived watch mode (e.g. environment
+variable changes) or when recovering from a stuck child process.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		c := client.New()
+		// Stop is idempotent — the daemon falls back to killPort if the
+		// child process isn't tracked, so a route that's already stopped
+		// is fine here.
+		if err := c.Stop(name); err != nil {
+			fmt.Fprintln(os.Stderr, "error stopping:", err)
+			os.Exit(1)
+		}
+		// Brief settle so the port releases before the daemon's preflight
+		// re-checks it on Start. Without this, a fast restart can hit a
+		// spurious "port in use" recovery prompt.
+		time.Sleep(300 * time.Millisecond)
+		if err := c.Start(name); err != nil {
+			fmt.Fprintln(os.Stderr, "error starting:", err)
+			os.Exit(1)
+		}
+		fmt.Printf("restarted: %s\n", name)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(restartCmd)
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -12,10 +12,11 @@ import (
 )
 
 type vibeConfig struct {
-	Name              string `json:"name"`
-	Port              int    `json:"port"`
-	Cmd               string `json:"cmd"`
-	OAuthCallbackPort int    `json:"oauth_callback_port,omitempty"`
+	Name              string         `json:"name"`
+	Port              int            `json:"port"`
+	Cmd               string         `json:"cmd"`
+	OAuthCallbackPort int            `json:"oauth_callback_port,omitempty"`
+	ReservePorts        map[string]int `json:"reserve_ports,omitempty"`
 }
 
 var startCmd = &cobra.Command{
@@ -28,7 +29,22 @@ var startCmd = &cobra.Command{
   vibe start myapp 3000 -- npm dev    Register and start a new app
 
 If port is omitted or set to 0 in vibe.json, a free port is auto-assigned
-and injected as the PORT environment variable.`,
+and injected as the PORT environment variable.
+
+vibe.json fields (used by 'vibe start' with no args):
+  name                  required — subdomain: name.vibe
+  cmd                   required — shell command to start the app
+  port                  optional — primary port; omit for auto-assign
+  reserve_ports         optional — {"name": port} map of auxiliary ports
+                        the cmd also binds; each is reserved across the
+                        route table and injected as $PORT_<UPPER_NAME>.
+                        Example: {"server": 3001} → $PORT_SERVER=3001
+  oauth_callback_port   optional — fixed localhost port that 307-forwards
+                        OAuth callbacks to name.vibe
+  icon                  optional — emoji for the dashboard
+  idle_timeout          optional — auto-stop after N minutes idle (0 = never)
+
+Full guide: curl http://localhost:7999/setup.md`,
 	Example: `  vibe start
   vibe start myapp
   vibe start myapp 3000 -- npm run dev`,
@@ -54,7 +70,7 @@ and injected as the PORT environment variable.`,
 			if _, err := fmt.Sscan(vibeArgs[1], &port); err != nil || port < 1 || port > 65535 {
 				return fmt.Errorf("invalid port: %s", vibeArgs[1])
 			}
-			return startNew(name, port, strings.Join(appCmd, " "), 0)
+			return startNew(name, port, strings.Join(appCmd, " "), 0, nil)
 
 		default:
 			return fmt.Errorf("usage: vibe start [name] [port] [-- command...]")
@@ -83,7 +99,7 @@ func startFromConfig() error {
 		return fmt.Errorf("vibe.json must have name and cmd fields")
 	}
 
-	return startNew(cfg.Name, cfg.Port, cfg.Cmd, cfg.OAuthCallbackPort)
+	return startNew(cfg.Name, cfg.Port, cfg.Cmd, cfg.OAuthCallbackPort, cfg.ReservePorts)
 }
 
 // startExisting starts an already-registered managed route.
@@ -97,7 +113,7 @@ func startExisting(name string) error {
 }
 
 // startNew registers a managed route and starts it.
-func startNew(name string, port int, command string, oauthCallbackPort int) error {
+func startNew(name string, port int, command string, oauthCallbackPort int, reservePorts map[string]int) error {
 	dir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("could not determine working directory: %w", err)
@@ -105,10 +121,11 @@ func startNew(name string, port int, command string, oauthCallbackPort int) erro
 
 	c := client.New()
 	req := client.RegisterRequest{
-		Name: name,
-		Port: port,
-		Cmd:  command,
-		Dir:  dir,
+		Name:       name,
+		Port:       port,
+		Cmd:        command,
+		Dir:        dir,
+		ReservePorts: reservePorts,
 	}
 	if oauthCallbackPort > 0 {
 		req.OAuthCallbackPort = &oauthCallbackPort

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -12,9 +12,10 @@ import (
 )
 
 type vibeConfig struct {
-	Name string `json:"name"`
-	Port int    `json:"port"`
-	Cmd  string `json:"cmd"`
+	Name              string `json:"name"`
+	Port              int    `json:"port"`
+	Cmd               string `json:"cmd"`
+	OAuthCallbackPort int    `json:"oauth_callback_port,omitempty"`
 }
 
 var startCmd = &cobra.Command{
@@ -53,7 +54,7 @@ and injected as the PORT environment variable.`,
 			if _, err := fmt.Sscan(vibeArgs[1], &port); err != nil || port < 1 || port > 65535 {
 				return fmt.Errorf("invalid port: %s", vibeArgs[1])
 			}
-			return startNew(name, port, strings.Join(appCmd, " "))
+			return startNew(name, port, strings.Join(appCmd, " "), 0)
 
 		default:
 			return fmt.Errorf("usage: vibe start [name] [port] [-- command...]")
@@ -82,7 +83,7 @@ func startFromConfig() error {
 		return fmt.Errorf("vibe.json must have name and cmd fields")
 	}
 
-	return startNew(cfg.Name, cfg.Port, cfg.Cmd)
+	return startNew(cfg.Name, cfg.Port, cfg.Cmd, cfg.OAuthCallbackPort)
 }
 
 // startExisting starts an already-registered managed route.
@@ -96,19 +97,23 @@ func startExisting(name string) error {
 }
 
 // startNew registers a managed route and starts it.
-func startNew(name string, port int, command string) error {
+func startNew(name string, port int, command string, oauthCallbackPort int) error {
 	dir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("could not determine working directory: %w", err)
 	}
 
 	c := client.New()
-	resp, err := c.Register(client.RegisterRequest{
+	req := client.RegisterRequest{
 		Name: name,
 		Port: port,
 		Cmd:  command,
 		Dir:  dir,
-	})
+	}
+	if oauthCallbackPort > 0 {
+		req.OAuthCallbackPort = &oauthCallbackPort
+	}
+	resp, err := c.Register(req)
 	if err != nil {
 		return fmt.Errorf("could not register %s: %w", name, err)
 	}

--- a/internal/cert/cert_test.go
+++ b/internal/cert/cert_test.go
@@ -1,6 +1,7 @@
 package cert
 
 import (
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -297,7 +298,7 @@ func writeExpiringCert(t *testing.T, dir string, ca *x509.Certificate, caKey int
 	keyBlock, _ := pem.Decode(keyData)
 	leafKey, _ := x509.ParseECPrivateKey(keyBlock.Bytes)
 
-	certDER, err := x509.CreateCertificate(nil, template, ca, &leafKey.PublicKey, caKey)
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca, &leafKey.PublicKey, caKey)
 	if err != nil {
 		t.Fatalf("create expiring cert: %v", err)
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -61,6 +61,11 @@ func (c *Client) do(method, path string, body any) ([]byte, int, error) {
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	// Daemon's start/stop handlers 303-redirect to the dashboard when this
+	// header is missing — that redirect points at https://local.vibe/, which
+	// the Unix-socket transport cannot follow (TLS over unix conn fails),
+	// surfacing as a spurious "daemon not running" error.
+	req.Header.Set("Accept", "application/json")
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("daemon not running — start it with: vibe daemon start")
@@ -72,13 +77,14 @@ func (c *Client) do(method, path string, body any) ([]byte, int, error) {
 
 // RegisterRequest mirrors the daemon API body.
 type RegisterRequest struct {
-	Name              string `json:"name"`
-	Port              int    `json:"port"`
-	PID               *int   `json:"pid,omitempty"`
-	TTL               *int   `json:"ttl,omitempty"`
-	Cmd               string `json:"cmd,omitempty"`
-	Dir               string `json:"dir,omitempty"`
-	OAuthCallbackPort *int   `json:"oauth_callback_port,omitempty"`
+	Name              string         `json:"name"`
+	Port              int            `json:"port"`
+	PID               *int           `json:"pid,omitempty"`
+	TTL               *int           `json:"ttl,omitempty"`
+	Cmd               string         `json:"cmd,omitempty"`
+	Dir               string         `json:"dir,omitempty"`
+	OAuthCallbackPort *int           `json:"oauth_callback_port,omitempty"`
+	ReservePorts        map[string]int `json:"reserve_ports,omitempty"`
 }
 
 type RegisterResponse struct {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -72,12 +72,13 @@ func (c *Client) do(method, path string, body any) ([]byte, int, error) {
 
 // RegisterRequest mirrors the daemon API body.
 type RegisterRequest struct {
-	Name string `json:"name"`
-	Port int    `json:"port"`
-	PID  *int   `json:"pid,omitempty"`
-	TTL  *int   `json:"ttl,omitempty"`
-	Cmd  string `json:"cmd,omitempty"`
-	Dir  string `json:"dir,omitempty"`
+	Name              string `json:"name"`
+	Port              int    `json:"port"`
+	PID               *int   `json:"pid,omitempty"`
+	TTL               *int   `json:"ttl,omitempty"`
+	Cmd               string `json:"cmd,omitempty"`
+	Dir               string `json:"dir,omitempty"`
+	OAuthCallbackPort *int   `json:"oauth_callback_port,omitempty"`
 }
 
 type RegisterResponse struct {
@@ -87,15 +88,16 @@ type RegisterResponse struct {
 }
 
 type RouteInfo struct {
-	Name         string     `json:"name"`
-	Port         int        `json:"port"`
-	PID          *int       `json:"pid,omitempty"`
-	RegisteredAt time.Time  `json:"registered_at"`
-	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
-	Type         string     `json:"type"`
-	Running      bool       `json:"running"`
-	Ready        bool       `json:"ready"`
-	URL          string     `json:"url"`
+	Name              string     `json:"name"`
+	Port              int        `json:"port"`
+	PID               *int       `json:"pid,omitempty"`
+	RegisteredAt      time.Time  `json:"registered_at"`
+	ExpiresAt         *time.Time `json:"expires_at,omitempty"`
+	Type              string     `json:"type"`
+	Running           bool       `json:"running"`
+	Ready             bool       `json:"ready"`
+	URL               string     `json:"url"`
+	OAuthCallbackPort int        `json:"oauth_callback_port,omitempty"`
 }
 
 type HealthResponse struct {

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -92,6 +92,7 @@ type registerRequest struct {
 	Icon               string `json:"icon,omitempty"`
 	Proxy              *bool  `json:"proxy,omitempty"`                // bookmark: reverse-proxy instead of 307-redirect
 	InsecureSkipVerify *bool  `json:"insecure_skip_verify,omitempty"` // bookmark+proxy: skip upstream TLS verify
+	OAuthCallbackPort  *int   `json:"oauth_callback_port,omitempty"`
 }
 
 type routeResponse struct {
@@ -109,6 +110,7 @@ type routeResponse struct {
 	Icon               string     `json:"icon,omitempty"`
 	Proxy              bool       `json:"proxy,omitempty"`
 	InsecureSkipVerify bool       `json:"insecure_skip_verify,omitempty"`
+	OAuthCallbackPort  int        `json:"oauth_callback_port,omitempty"`
 }
 
 // apiHandler routes /_api/* requests to the appropriate handler.
@@ -222,6 +224,12 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "proxy requires a url")
 		return
 	}
+	if req.OAuthCallbackPort != nil {
+		if err := s.validateOAuthBridgeConfig(req.Name, req.Port, *req.OAuthCallbackPort); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
 
 	// Reject if a managed route with this name is already running.
 	if existing, ok := s.table.Get(req.Name); ok && existing.Type == RouteManaged && existing.Running.Load() {
@@ -249,6 +257,9 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.InsecureSkipVerify != nil {
 		route.InsecureSkipVerify = *req.InsecureSkipVerify
+	}
+	if req.OAuthCallbackPort != nil {
+		route.OAuthCallbackPort = *req.OAuthCallbackPort
 	}
 
 	switch {
@@ -310,6 +321,15 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		go s.waitForReady(route)
 	}
 
+	if err := s.reconcileOAuthBridgeListeners(); err != nil {
+		if route.Type == RouteManaged {
+			_ = s.procs.Stop(route.Name)
+		}
+		s.table.Remove(route.Name)
+		writeJSONError(w, http.StatusConflict, err.Error())
+		return
+	}
+
 	if route.Type == RouteSticky || route.Type == RouteManaged || route.Type == RouteBookmark {
 		_ = s.saveStickyRoutes()
 	}
@@ -331,6 +351,9 @@ func (s *Server) handleDeregister(w http.ResponseWriter, _ *http.Request, name s
 		_ = s.procs.Stop(name)
 	}
 	s.table.Remove(name)
+	if err := s.reconcileOAuthBridgeListeners(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: oauth bridge listener reconcile failed: %v\n", err)
+	}
 	_ = s.saveStickyRoutes()
 	json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
@@ -379,6 +402,15 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request, name strin
 		writeJSONError(w, http.StatusBadRequest, "proxy requires a url")
 		return
 	}
+	originalName := route.Name
+	originalPort := route.Port
+	originalExternalURL := route.ExternalURL
+	originalType := route.Type
+	originalIdleTimeout := route.IdleTimeout
+	originalIcon := route.Icon
+	originalProxy := route.Proxy
+	originalInsecureSkipVerify := route.InsecureSkipVerify
+	originalOAuthCallbackPort := route.OAuthCallbackPort
 	if req.Port != 0 {
 		route.Port = req.Port
 	}
@@ -405,7 +437,39 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request, name strin
 	if req.InsecureSkipVerify != nil {
 		route.InsecureSkipVerify = *req.InsecureSkipVerify
 	}
+	if req.OAuthCallbackPort != nil {
+		route.OAuthCallbackPort = *req.OAuthCallbackPort
+	}
+	if route.OAuthCallbackPort > 0 {
+		if err := s.validateOAuthBridgeConfig(route.Name, route.Port, route.OAuthCallbackPort); err != nil {
+			route.Name = originalName
+			route.Port = originalPort
+			route.ExternalURL = originalExternalURL
+			route.Type = originalType
+			route.IdleTimeout = originalIdleTimeout
+			route.Icon = originalIcon
+			route.Proxy = originalProxy
+			route.InsecureSkipVerify = originalInsecureSkipVerify
+			route.OAuthCallbackPort = originalOAuthCallbackPort
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
 	s.table.Add(route)
+	if err := s.reconcileOAuthBridgeListeners(); err != nil {
+		route.Name = originalName
+		route.Port = originalPort
+		route.ExternalURL = originalExternalURL
+		route.Type = originalType
+		route.IdleTimeout = originalIdleTimeout
+		route.Icon = originalIcon
+		route.Proxy = originalProxy
+		route.InsecureSkipVerify = originalInsecureSkipVerify
+		route.OAuthCallbackPort = originalOAuthCallbackPort
+		s.table.Add(route)
+		writeJSONError(w, http.StatusConflict, err.Error())
+		return
+	}
 	_ = s.saveStickyRoutes()
 	json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
@@ -515,9 +579,10 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request, name string)
 // the user can tell the daemon self-healed.
 //
 // Response shape:
-//   { ok: true,  port: 3001, from: 3000 }    // auto-resolved
-//   { ok: true,  port: 3000, note: "..." }   // nothing to fix, already reachable
-//   { ok: false, port: 3000, reason: "...", restartable: true } // no candidate found
+//
+//	{ ok: true,  port: 3001, from: 3000 }    // auto-resolved
+//	{ ok: true,  port: 3000, note: "..." }   // nothing to fix, already reachable
+//	{ ok: false, port: 3000, reason: "...", restartable: true } // no candidate found
 func (s *Server) handleRepair(w http.ResponseWriter, _ *http.Request, name string) {
 	route, ok := s.table.Get(name)
 	if !ok {
@@ -649,6 +714,28 @@ func (s *Server) waitForReady(route *Route) {
 			// so only mark Ready=false. Running reflects actual process state.
 			if !s.isPortReady(route.Port) {
 				route.Ready.Store(false)
+				// Surface something actionable on /ready so the start page
+				// can render the log tail + a recovery button instead of a
+				// bare "check logs" timeout message. Prefer a log-scan hint
+				// (EADDRINUSE, orphan PID, etc.); otherwise fall back to
+				// "restart" — stop the stuck child and try again.
+				logPath := filepath.Join(s.configDir(), route.Name+".log")
+				tail := tailLogFile(logPath, 24)
+				f := &Failure{
+					Message: fmt.Sprintf("Server started but never bound port %d within %s.", route.Port, timeout),
+					Log:     tail,
+				}
+				if rec := scanLogForRecovery(tail); rec != nil {
+					f.Recovery = rec
+				} else if pid, ok := route.PIDValue(); ok && processAlive(pid) {
+					f.Recovery = &Recovery{
+						Action:  "restart",
+						Message: fmt.Sprintf("Process (PID %d) is running but never bound port %d. Restart it?", pid, route.Port),
+						PID:     pid,
+						Port:    route.Port,
+					}
+				}
+				route.SetFailure(f)
 			}
 			return
 		case <-ticker.C:
@@ -813,6 +900,7 @@ func toResponse(r *Route, tld, scheme string) routeResponse {
 		Icon:               r.Icon,
 		Proxy:              r.Proxy,
 		InsecureSkipVerify: r.InsecureSkipVerify,
+		OAuthCallbackPort:  r.OAuthCallbackPort,
 	}
 	if r.Type == RouteBookmark {
 		resp.URL = r.ExternalURL

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -45,6 +46,156 @@ func failureFromError(err error) *Failure {
 	return f
 }
 
+// reservePortNamePattern restricts reserve_port keys to env-var-safe identifiers.
+// The name is uppercased and prefixed with "PORT_" when injected as an env
+// var (e.g. {"server": 3001} → PORT_SERVER=3001), so the key has to be a
+// legal POSIX env var suffix to begin with.
+var reservePortNamePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
+
+// validateReservePorts checks a reserve_ports map for: legal name shape, no
+// collision with the primary or oauth_callback_port, no port out of range,
+// no two names mapping to the same port. Returns a normalized copy with
+// names lower-cased so config files can use either case interchangeably
+// (env var injection always uppercases on the way out).
+//
+// The forbidden name "PORT" is rejected explicitly — using it would make
+// PORT_<NAME> = PORT, which would either shadow or duplicate the primary
+// port's env var depending on map iteration order. Confusing either way.
+func validateReservePorts(reserve map[string]int, primary, oauthCallback int) (map[string]int, error) {
+	if len(reserve) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]int, len(reserve))
+	seenPort := make(map[int]string, len(reserve))
+	for rawName, p := range reserve {
+		name := strings.ToLower(strings.TrimSpace(rawName))
+		if name == "" {
+			return nil, fmt.Errorf("reserve_ports has empty name")
+		}
+		if !reservePortNamePattern.MatchString(name) {
+			return nil, fmt.Errorf("reserve_ports name %q must match [a-zA-Z][a-zA-Z0-9_]*", rawName)
+		}
+		if strings.EqualFold(name, "port") {
+			return nil, fmt.Errorf("reserve_ports name %q is reserved (it would collide with the primary $PORT env var)", rawName)
+		}
+		if p < 1 || p > 65535 {
+			return nil, fmt.Errorf("reserve_ports[%q] = %d is out of range (1-65535)", rawName, p)
+		}
+		if p == primary {
+			return nil, fmt.Errorf("reserve_ports[%q] = %d collides with the route's primary port", rawName, p)
+		}
+		if oauthCallback > 0 && p == oauthCallback {
+			return nil, fmt.Errorf("reserve_ports[%q] = %d collides with oauth_callback_port", rawName, p)
+		}
+		if other, dup := seenPort[p]; dup {
+			return nil, fmt.Errorf("reserve_ports[%q] and reserve_ports[%q] both map to port %d", other, rawName, p)
+		}
+		if _, exists := out[name]; exists {
+			return nil, fmt.Errorf("reserve_ports has duplicate name %q (case-insensitive)", rawName)
+		}
+		seenPort[p] = rawName
+		out[name] = p
+	}
+	return out, nil
+}
+
+// reservePortValuesSorted returns the port numbers from a reserve_ports map
+// sorted by name, so iteration order is deterministic for preflight checks
+// and env var injection.
+func reservePortValuesSorted(reserve map[string]int) []struct {
+	Name string
+	Port int
+} {
+	if len(reserve) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(reserve))
+	for n := range reserve {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]struct {
+		Name string
+		Port int
+	}, len(names))
+	for i, n := range names {
+		out[i].Name = n
+		out[i].Port = reserve[n]
+	}
+	return out
+}
+
+// reservePortConflictsWith returns the offending port and the route that owns
+// it if any of this route's reserve_ports values is already claimed by another
+// route's primary, OAuth callback, or reserve port. Used to surface config-time
+// collisions before the spawn.
+func reservePortConflictsWith(table *RouteTable, ownName string, reserve map[string]int) (int, string) {
+	if len(reserve) == 0 {
+		return 0, ""
+	}
+	want := make(map[int]bool, len(reserve))
+	for _, p := range reserve {
+		want[p] = true
+	}
+	for _, r := range table.List() {
+		if r.Name == ownName {
+			continue
+		}
+		if r.Port > 0 && want[r.Port] {
+			return r.Port, r.Name
+		}
+		if r.OAuthCallbackPort > 0 && want[r.OAuthCallbackPort] {
+			return r.OAuthCallbackPort, r.Name
+		}
+		for _, p := range r.ReservePorts {
+			if want[p] {
+				return p, r.Name
+			}
+		}
+	}
+	return 0, ""
+}
+
+// preflightPort verifies that a port is currently free, attempting to clear
+// any stale process via killPort before giving up. Returns a Recovery hint
+// when the port is still held by an external process after the kill attempt;
+// returns nil when the port is free (or only held by daemon-managed PIDs).
+//
+// This is the shared entry point used for the route's primary port AND each
+// of its reserve_ports — both go through the same kill-and-recheck flow so
+// the user gets a single, consistent recovery UX regardless of which port
+// is the offender.
+func (s *Server) preflightPort(port int) *Recovery {
+	if port <= 0 {
+		return nil
+	}
+	if !s.isPortReady(port) {
+		return nil
+	}
+	s.killPort(port)
+	time.Sleep(500 * time.Millisecond)
+	if !s.isPortReady(port) {
+		return nil
+	}
+	return s.buildPortConflictRecovery(port)
+}
+
+// writePortConflict sends a 409 Conflict with a recovery hint identifying the
+// process holding the port (when one can be discovered). The startpage reads
+// the recovery field and renders a one-click "Kill PID X and retry" button
+// instead of just a useless "Retry" that would hit the same conflict.
+func writePortConflict(w http.ResponseWriter, port int, recovery *Recovery) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusConflict)
+	resp := map[string]any{
+		"error": fmt.Sprintf("port %d is already in use by another process", port),
+	}
+	if recovery != nil {
+		resp["recovery"] = recovery
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // writeStartFailure sends a managed-process start error with the log tail and
 // a recovery hint attached when one of the known patterns matches. The
 // dashboard surfaces the hint as a one-click "kill and retry" button.
@@ -61,6 +212,20 @@ func writeStartFailure(w http.ResponseWriter, status int, err error) {
 		resp["recovery"] = f.Recovery
 	}
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// isBrowserFormRequest returns true for requests that came from a dashboard
+// HTML form submission (so handlers should 303-redirect back to the dashboard
+// instead of returning JSON). Identified by the form-encoded Content-Type —
+// the previous "Accept != application/json" heuristic mis-classified CLI
+// clients that omit Accept entirely, which then chased a 303 to https://local.vibe/
+// over the Unix socket and surfaced as a spurious "daemon not running" error.
+func isBrowserFormRequest(r *http.Request) bool {
+	ct := r.Header.Get("Content-Type")
+	if i := strings.Index(ct, ";"); i != -1 {
+		ct = ct[:i]
+	}
+	return strings.TrimSpace(ct) == "application/x-www-form-urlencoded"
 }
 
 // validateExternalURL rejects any bookmark target that isn't a plain http://
@@ -81,18 +246,19 @@ func validateExternalURL(raw string) error {
 }
 
 type registerRequest struct {
-	Name               string `json:"name"`
-	Port               int    `json:"port"`
-	PID                *int   `json:"pid,omitempty"`
-	TTL                *int   `json:"ttl,omitempty"`
-	Cmd                string `json:"cmd,omitempty"`
-	Dir                string `json:"dir,omitempty"`
-	URL                string `json:"url,omitempty"`
-	IdleTimeout        *int   `json:"idle_timeout,omitempty"` // minutes; 0 = never
-	Icon               string `json:"icon,omitempty"`
-	Proxy              *bool  `json:"proxy,omitempty"`                // bookmark: reverse-proxy instead of 307-redirect
-	InsecureSkipVerify *bool  `json:"insecure_skip_verify,omitempty"` // bookmark+proxy: skip upstream TLS verify
-	OAuthCallbackPort  *int   `json:"oauth_callback_port,omitempty"`
+	Name               string         `json:"name"`
+	Port               int            `json:"port"`
+	PID                *int           `json:"pid,omitempty"`
+	TTL                *int           `json:"ttl,omitempty"`
+	Cmd                string         `json:"cmd,omitempty"`
+	Dir                string         `json:"dir,omitempty"`
+	URL                string         `json:"url,omitempty"`
+	IdleTimeout        *int           `json:"idle_timeout,omitempty"` // minutes; 0 = never
+	Icon               string         `json:"icon,omitempty"`
+	Proxy              *bool          `json:"proxy,omitempty"`                // bookmark: reverse-proxy instead of 307-redirect
+	InsecureSkipVerify *bool          `json:"insecure_skip_verify,omitempty"` // bookmark+proxy: skip upstream TLS verify
+	OAuthCallbackPort  *int           `json:"oauth_callback_port,omitempty"`
+	ReservePorts         map[string]int `json:"reserve_ports,omitempty"` // managed: named auxiliary ports, exposed as PORT_<UPPER_NAME>
 }
 
 type routeResponse struct {
@@ -115,23 +281,25 @@ type routeResponse struct {
 
 // apiHandler routes /_api/* requests to the appropriate handler.
 func (s *Server) apiHandler(w http.ResponseWriter, r *http.Request) {
-	// The daemon API is only meant for the dashboard host (local.vibe) and
-	// localhost/unix-socket CLI callers. On any other .vibe host, /_api/*
-	// belongs to the proxied upstream — e.g. Jekyll Admin fetches
-	// /_api/configuration — so fall through to the normal request router.
+	path := strings.TrimPrefix(r.URL.Path, "/_api")
+
+	// On non-local .vibe hosts, reserve only the daemon's known API routes.
+	// Unknown /_api/* paths should continue through normal proxying so apps
+	// that expose their own /_api namespace (e.g. Jekyll Admin) still work.
 	host := r.Host
 	if idx := strings.Index(host, ":"); idx != -1 {
 		host = host[:idx]
 	}
+	nonLocalVibeHost := false
 	if strings.HasSuffix(host, "."+s.cfg.Daemon.TLD) {
 		name := strings.TrimSuffix(host, "."+s.cfg.Daemon.TLD)
-		if name != "local" {
-			s.routeRequest(w, r)
-			return
-		}
+		nonLocalVibeHost = name != "local"
+	}
+	if nonLocalVibeHost && !isDaemonAPIPath(r.Method, path) {
+		s.routeRequest(w, r)
+		return
 	}
 
-	path := strings.TrimPrefix(r.URL.Path, "/_api")
 	w.Header().Set("Content-Type", "application/json")
 
 	switch {
@@ -167,7 +335,38 @@ func (s *Server) apiHandler(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodPut && path == "/preferences":
 		s.handleSetPreferences(w, r)
 	default:
+		if nonLocalVibeHost {
+			s.routeRequest(w, r)
+			return
+		}
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+	}
+}
+
+func isDaemonAPIPath(method, path string) bool {
+	switch {
+	case method == http.MethodGet && path == "/health":
+		return true
+	case method == http.MethodGet && strings.HasPrefix(path, "/routes/") && strings.HasSuffix(path, "/ready"):
+		return true
+	case method == http.MethodGet && strings.HasPrefix(path, "/routes/") && strings.HasSuffix(path, "/repair"):
+		return true
+	case method == http.MethodGet && path == "/routes":
+		return true
+	case method == http.MethodPost && path == "/routes":
+		return true
+	case method == http.MethodPut && strings.HasPrefix(path, "/routes/"):
+		return true
+	case method == http.MethodDelete && strings.HasPrefix(path, "/routes/"):
+		return true
+	case method == http.MethodPost && strings.HasPrefix(path, "/routes/") && strings.HasSuffix(path, "/stop"):
+		return true
+	case method == http.MethodPost && strings.HasPrefix(path, "/routes/") && strings.HasSuffix(path, "/start"):
+		return true
+	case method == http.MethodPut && path == "/preferences":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -230,6 +429,19 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	oauthCB := 0
+	if req.OAuthCallbackPort != nil {
+		oauthCB = *req.OAuthCallbackPort
+	}
+	reservePorts, err := validateReservePorts(req.ReservePorts, req.Port, oauthCB)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if conflictPort, conflictRoute := reservePortConflictsWith(s.table, req.Name, reservePorts); conflictPort != 0 {
+		writeJSONError(w, http.StatusConflict, fmt.Sprintf("reserve_ports value %d conflicts with route %q", conflictPort, conflictRoute))
+		return
+	}
 
 	// Reject if a managed route with this name is already running.
 	if existing, ok := s.table.Get(req.Name); ok && existing.Type == RouteManaged && existing.Running.Load() {
@@ -261,6 +473,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	if req.OAuthCallbackPort != nil {
 		route.OAuthCallbackPort = *req.OAuthCallbackPort
 	}
+	route.ReservePorts = reservePorts
 
 	switch {
 	case req.URL != "":
@@ -294,16 +507,22 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			}
 			route.Port = port
 		}
-		// Clear stale process on the port before launching.
-		if route.Port > 0 && s.isPortReady(route.Port) {
-			s.killPort(route.Port)
-			time.Sleep(500 * time.Millisecond)
-			// Verify the port was actually freed.
-			if s.isPortReady(route.Port) {
+		// Clear stale process on the primary port and each reserve_port before
+		// launching. Reserve ports check first so a multi-port app surfaces
+		// the right collision instead of silently bleeding into a stale
+		// holder of a non-routed port (the screener.vibe / task-tracker bug).
+		// Iterate in sorted-name order so behavior is deterministic.
+		for _, kv := range reservePortValuesSorted(route.ReservePorts) {
+			if rec := s.preflightPort(kv.Port); rec != nil {
 				s.table.Remove(route.Name)
-				writeJSONError(w, http.StatusConflict, fmt.Sprintf("port %d is already in use by another process", route.Port))
+				writePortConflict(w, kv.Port, rec)
 				return
 			}
+		}
+		if rec := s.preflightPort(route.Port); rec != nil {
+			s.table.Remove(route.Name)
+			writePortConflict(w, route.Port, rec)
+			return
 		}
 		pid, err := s.procs.Start(route)
 		if err != nil {
@@ -480,6 +699,14 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request, name string
 		writeJSONError(w, http.StatusNotFound, "route not found")
 		return
 	}
+	// Re-read vibe.json from the route's Dir before launching so edits to
+	// oauth_callback_port, reserve_ports, or cmd take effect without forcing
+	// the user to deregister + re-register. Errors here are config conflicts
+	// that should block the start; missing/malformed files are silent no-ops.
+	if err := s.syncRouteFromVibeJSON(route); err != nil {
+		writeJSONError(w, http.StatusConflict, err.Error())
+		return
+	}
 	if route.Cmd == "" {
 		writeJSONError(w, http.StatusBadRequest, "route has no launch command")
 		return
@@ -516,16 +743,27 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request, name string
 		}
 		route.Port = port
 	}
-	// If the port is already in use, try to clear the stale process before starting.
-	if route.Port > 0 && s.isPortReady(route.Port) {
-		s.killPort(route.Port)
-		// Give the OS a moment to release the port.
-		time.Sleep(500 * time.Millisecond)
-		// Verify the port was actually freed.
-		if s.isPortReady(route.Port) {
-			writeJSONError(w, http.StatusConflict, fmt.Sprintf("port %d is already in use by another process", route.Port))
+	// Pre-flight every port the cmd will bind: each reserve_port first, then
+	// the primary. Persist the recovery on the route's Failure so a startpage
+	// reload rehydrates the "Kill PID X and retry" button via
+	// startPageRecoveryInitJS instead of showing a bare error.
+	for _, kv := range reservePortValuesSorted(route.ReservePorts) {
+		if rec := s.preflightPort(kv.Port); rec != nil {
+			route.SetFailure(&Failure{
+				Message:  fmt.Sprintf("reserve_ports[%q] = %d is already in use by another process", kv.Name, kv.Port),
+				Recovery: rec,
+			})
+			writePortConflict(w, kv.Port, rec)
 			return
 		}
+	}
+	if rec := s.preflightPort(route.Port); rec != nil {
+		route.SetFailure(&Failure{
+			Message:  fmt.Sprintf("port %d is already in use by another process", route.Port),
+			Recovery: rec,
+		})
+		writePortConflict(w, route.Port, rec)
+		return
 	}
 
 	pid, err := s.procs.Start(route)
@@ -544,7 +782,7 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request, name string
 	go s.waitForReady(route)
 
 	// If request came from browser form, redirect back to the app.
-	if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" || r.Header.Get("Accept") != "application/json" {
+	if isBrowserFormRequest(r) {
 		http.Redirect(w, r, fmt.Sprintf("%s://%s.%s/", s.vibeScheme(), name, s.cfg.Daemon.TLD), http.StatusSeeOther)
 		return
 	}
@@ -566,7 +804,7 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request, name string)
 	route.ClearPID()
 
 	// If request came from browser form, redirect back to dashboard.
-	if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" || r.Header.Get("Accept") != "application/json" {
+	if isBrowserFormRequest(r) {
 		http.Redirect(w, r, fmt.Sprintf("%s://local.%s/", s.vibeScheme(), s.cfg.Daemon.TLD), http.StatusSeeOther)
 		return
 	}

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -595,7 +595,11 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request, name strin
 	if req.Name != "" {
 		req.Name = strings.ToLower(req.Name)
 	}
-	// If the name changed, validate and remove old entry.
+	// Validate a rename up-front, but defer the table mutation until after
+	// every other validation has passed — otherwise a later early-return
+	// (bad URL, OAuth port collision, etc.) would leave the route removed
+	// from the table but never re-added under any name.
+	renaming := false
 	if req.Name != "" && req.Name != name {
 		if !validName.MatchString(req.Name) {
 			writeJSONError(w, http.StatusBadRequest, "invalid name — use lowercase letters, digits, and hyphens")
@@ -609,8 +613,7 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request, name strin
 			writeJSONError(w, http.StatusConflict, "a route with that name already exists")
 			return
 		}
-		s.table.Remove(name)
-		route.Name = req.Name
+		renaming = true
 	}
 	if req.URL != "" {
 		if err := validateExternalURL(req.URL); err != nil {
@@ -625,6 +628,9 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request, name strin
 		return
 	}
 	originalName := route.Name
+	if renaming {
+		route.Name = req.Name
+	}
 	originalPort := route.Port
 	originalExternalURL := route.ExternalURL
 	originalType := route.Type
@@ -682,8 +688,16 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request, name strin
 			return
 		}
 	}
+	// Commit any rename now that all validation has succeeded: remove the
+	// old key, then re-add under the (possibly new) name.
+	if renaming {
+		s.table.Remove(name)
+	}
 	s.table.Add(route)
 	if err := s.reconcileOAuthBridgeListeners(); err != nil {
+		if renaming {
+			s.table.Remove(route.Name)
+		}
 		route.Name = originalName
 		route.Port = originalPort
 		route.ExternalURL = originalExternalURL

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -31,8 +31,9 @@ func writeJSONError(w http.ResponseWriter, status int, msg string) {
 }
 
 // failureFromError turns a Start() error into a Failure record, scanning the
-// log tail (if present) for an actionable recovery hint.
-func failureFromError(err error) *Failure {
+// log tail (if present) for an actionable recovery hint. cmd is the route's
+// current command line — used for cmd-rewrite suggestions like python→python3.
+func failureFromError(err error, cmd string) *Failure {
 	if err == nil {
 		return nil
 	}
@@ -41,7 +42,7 @@ func failureFromError(err error) *Failure {
 	if errors.As(err, &se) {
 		f.Message = se.Err.Error()
 		f.Log = se.Tail
-		f.Recovery = scanLogForRecovery(se.Tail)
+		f.Recovery = scanLogForRecovery(se.Tail, cmd)
 	}
 	return f
 }
@@ -199,11 +200,11 @@ func writePortConflict(w http.ResponseWriter, port int, recovery *Recovery) {
 // writeStartFailure sends a managed-process start error with the log tail and
 // a recovery hint attached when one of the known patterns matches. The
 // dashboard surfaces the hint as a one-click "kill and retry" button.
-func writeStartFailure(w http.ResponseWriter, status int, err error) {
+func writeStartFailure(w http.ResponseWriter, status int, err error, cmd string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 
-	f := failureFromError(err)
+	f := failureFromError(err, cmd)
 	resp := map[string]any{"error": f.Message}
 	if f.Log != "" {
 		resp["log"] = f.Log
@@ -254,7 +255,7 @@ type registerRequest struct {
 	Dir                string         `json:"dir,omitempty"`
 	URL                string         `json:"url,omitempty"`
 	IdleTimeout        *int           `json:"idle_timeout,omitempty"` // minutes; 0 = never
-	Icon               string         `json:"icon,omitempty"`
+	Icon               *string        `json:"icon,omitempty"`
 	Proxy              *bool          `json:"proxy,omitempty"`                // bookmark: reverse-proxy instead of 307-redirect
 	InsecureSkipVerify *bool          `json:"insecure_skip_verify,omitempty"` // bookmark+proxy: skip upstream TLS verify
 	OAuthCallbackPort  *int           `json:"oauth_callback_port,omitempty"`
@@ -463,7 +464,9 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	if req.IdleTimeout != nil {
 		route.IdleTimeout = *req.IdleTimeout
 	}
-	route.Icon = req.Icon
+	if req.Icon != nil {
+		route.Icon = *req.Icon
+	}
 	if req.Proxy != nil {
 		route.Proxy = *req.Proxy
 	}
@@ -527,7 +530,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		pid, err := s.procs.Start(route)
 		if err != nil {
 			s.table.Remove(route.Name)
-			writeStartFailure(w, http.StatusInternalServerError, err)
+			writeStartFailure(w, http.StatusInternalServerError, err, route.Cmd)
 			return
 		}
 		route.SetPID(pid)
@@ -636,8 +639,13 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request, name strin
 	if req.IdleTimeout != nil {
 		route.IdleTimeout = *req.IdleTimeout
 	}
-	if req.Icon != "" {
-		route.Icon = req.Icon
+	if req.Icon != nil {
+		route.Icon = *req.Icon
+	}
+	// Cmd is only meaningful on managed routes — silently ignore on others so
+	// generic clients can PUT a full route shape without surprises.
+	if req.Cmd != "" && route.Type == RouteManaged {
+		route.Cmd = req.Cmd
 	}
 	if req.URL != "" {
 		route.ExternalURL = req.URL
@@ -770,8 +778,8 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request, name string
 	if err != nil {
 		route.Running.Store(false)
 		route.Ready.Store(false)
-		route.SetFailure(failureFromError(err))
-		writeStartFailure(w, http.StatusInternalServerError, err)
+		route.SetFailure(failureFromError(err, route.Cmd))
+		writeStartFailure(w, http.StatusInternalServerError, err, route.Cmd)
 		return
 	}
 	route.SetPID(pid)
@@ -963,7 +971,7 @@ func (s *Server) waitForReady(route *Route) {
 					Message: fmt.Sprintf("Server started but never bound port %d within %s.", route.Port, timeout),
 					Log:     tail,
 				}
-				if rec := scanLogForRecovery(tail); rec != nil {
+				if rec := scanLogForRecovery(tail, route.Cmd); rec != nil {
 					f.Recovery = rec
 				} else if pid, ok := route.PIDValue(); ok && processAlive(pid) {
 					f.Recovery = &Recovery{
@@ -986,7 +994,7 @@ func (s *Server) waitForReady(route *Route) {
 				// Scan the log tail for an actionable recovery hint (e.g.
 				// Next.js's "Another dev server running — PID: 23674") so
 				// whoever polls /ready can offer a one-click "kill and retry".
-				route.SetFailure(failureFromLog(route.Name, "process exited before becoming ready"))
+				route.SetFailure(failureFromLog(route.Name, "process exited before becoming ready", route.Cmd))
 				return
 			}
 			if !ok || !route.Running.Load() {
@@ -1009,12 +1017,12 @@ func (s *Server) waitForReady(route *Route) {
 // running the recovery-hint scanner over it. Used when a managed process
 // dies asynchronously (after Start() returned) — we don't have an error
 // value from Start, only what the process wrote to its log.
-func failureFromLog(routeName, message string) *Failure {
+func failureFromLog(routeName, message, cmd string) *Failure {
 	logPath := filepath.Join(config.Dir(), routeName+".log")
 	tail := tailLogFile(logPath, 12)
 	f := &Failure{Message: message, Log: tail}
 	if tail != "" {
-		f.Recovery = scanLogForRecovery(tail)
+		f.Recovery = scanLogForRecovery(tail, cmd)
 	}
 	return f
 }

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -140,6 +140,34 @@ func TestAPIUpdate(t *testing.T) {
 	}
 }
 
+// TestAPIUpdateRenameWithValidationFailure regresses a bug where a rename
+// + later validation failure (bad URL) removed the old key from the table
+// but never re-added it, silently deleting the route.
+func TestAPIUpdateRenameWithValidationFailure(t *testing.T) {
+	s := testServer()
+
+	body, _ := json.Marshal(map[string]any{"name": "foo", "port": 3000})
+	req := httptest.NewRequest("POST", "/_api/routes", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	s.apiHandler(httptest.NewRecorder(), req)
+
+	body, _ = json.Marshal(map[string]any{"name": "bar", "url": "not-a-valid-url"})
+	req = httptest.NewRequest("PUT", "/_api/routes/foo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected validation error, got 200")
+	}
+	if _, ok := s.table.Get("foo"); !ok {
+		t.Errorf("route foo vanished after failed rename+update")
+	}
+	if _, ok := s.table.Get("bar"); ok {
+		t.Errorf("route bar should not exist after failed validation")
+	}
+}
+
 func TestAPIUpdateIdleTimeout(t *testing.T) {
 	s := testServer()
 

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -881,7 +881,7 @@ func TestWriteStartFailureIncludesRecoveryHint(t *testing.T) {
 		Tail: tail,
 	}
 	w := httptest.NewRecorder()
-	writeStartFailure(w, http.StatusInternalServerError, se)
+	writeStartFailure(w, http.StatusInternalServerError, se, "")
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d; want 500", w.Code)

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -505,14 +507,366 @@ with socketserver.TCPServer(("127.0.0.1", %d), http.server.BaseHTTPRequestHandle
 		t.Fatalf("expected error when port %d is occupied, but got 200 OK: %s", port, w.Body.String())
 	}
 
-	// Should get an error response indicating port conflict.
+	// Should get an error response indicating port conflict, with a recovery
+	// hint identifying the holder PID so the dashboard can offer a one-click
+	// "Kill PID X and retry" button instead of a useless plain "Retry".
 	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	errMsg, _ := resp["error"].(string)
 	if errMsg == "" {
 		t.Error("expected error message in response body")
 	}
-	t.Logf("got expected error: status=%d error=%q", w.Code, errMsg)
+	rec, ok := resp["recovery"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected recovery hint in response; body: %s", w.Body.String())
+	}
+	if rec["action"] != "kill_pid" {
+		t.Errorf("recovery action = %v; want kill_pid", rec["action"])
+	}
+	if int(rec["pid"].(float64)) != holder.Process.Pid {
+		t.Errorf("recovery pid = %v; want %d", rec["pid"], holder.Process.Pid)
+	}
+	t.Logf("got expected error+recovery: status=%d error=%q recovery=%v", w.Code, errMsg, rec)
+}
+
+// TestHandleStartPortOccupiedAttachesRecovery is the screener.vibe regression:
+// a stale dev-server process holds the route's port, the user clicks Start
+// from the not-running page, the daemon can't free the port, and we MUST
+// surface a recovery hint with the offending PID so the startpage can offer
+// a one-click "Kill PID X and retry" instead of a bare "Retry" that fails
+// the same way again. Also verifies the recovery is persisted on the route's
+// Failure so a page reload rehydrates the button.
+func TestHandleStartPortOccupiedAttachesRecovery(t *testing.T) {
+	t.Parallel()
+	s := testServer()
+	s.ReadyTimeout = 2 * time.Second
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	holder := exec.Command("python3", "-c", fmt.Sprintf(
+		`import signal, http.server, socketserver
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+with socketserver.TCPServer(("127.0.0.1", %d), http.server.BaseHTTPRequestHandler) as s:
+    s.serve_forever()`, port))
+	holder.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := holder.Start(); err != nil {
+		t.Fatalf("start port holder: %v", err)
+	}
+	t.Cleanup(func() {
+		syscall.Kill(-holder.Process.Pid, syscall.SIGKILL)
+		holder.Wait()
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if dialErr == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !s.isPortReady(port) {
+		t.Fatalf("port holder never bound port %d", port)
+	}
+
+	// Pre-register the managed route in the table without starting it — this
+	// matches the state after a daemon restart with persisted routes, before
+	// the user clicks Start.
+	route := &Route{
+		Name:         "screener-repro",
+		Port:         port,
+		Type:         RouteManaged,
+		Cmd:          "sleep 60",
+		Dir:          t.TempDir(),
+		RegisteredAt: time.Now(),
+	}
+	s.table.Add(route)
+	t.Cleanup(func() { s.table.Remove(route.Name) })
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/_api/routes/%s/start", route.Name), nil)
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d; want 409; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v; body: %s", err, w.Body.String())
+	}
+	rec, ok := resp["recovery"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected recovery hint; body: %s", w.Body.String())
+	}
+	if rec["action"] != "kill_pid" {
+		t.Errorf("recovery action = %v; want kill_pid", rec["action"])
+	}
+	if int(rec["pid"].(float64)) != holder.Process.Pid {
+		t.Errorf("recovery pid = %v; want %d", rec["pid"], holder.Process.Pid)
+	}
+
+	// Reload-survival: the recovery must be persisted on the Route's Failure
+	// so the startpage's initRecovery hydration rehydrates the button.
+	failure := route.LoadFailure()
+	if failure == nil {
+		t.Fatalf("expected route.Failure to be set after port conflict")
+	}
+	if failure.Recovery == nil {
+		t.Fatalf("expected route.Failure.Recovery to be set; got %+v", failure)
+	}
+	if failure.Recovery.PID != holder.Process.Pid {
+		t.Errorf("persisted recovery pid = %d; want %d", failure.Recovery.PID, holder.Process.Pid)
+	}
+}
+
+// TestBuildPortConflictRecoveryFiltersAndShape covers three branches of the
+// port-conflict recovery builder using injected lsof/ps stubs:
+//   - the daemon's own PID is filtered out (safeKillPID would reject it),
+//   - exactly one remaining external PID becomes a kill_pid hint with the
+//     command name embedded in the message,
+//   - multiple external PIDs collapse to a kill_port hint.
+func TestBuildPortConflictRecoveryFiltersAndShape(t *testing.T) {
+	// NOT t.Parallel(): mutates package-level findPortHoldersFn / pidCommandFn,
+	// which the integration-style port-occupied tests read via the real handler.
+	s := testServer()
+
+	origHolders := findPortHoldersFn
+	origCmd := pidCommandFn
+	t.Cleanup(func() {
+		findPortHoldersFn = origHolders
+		pidCommandFn = origCmd
+	})
+
+	pidCommandFn = func(pid int) string {
+		if pid == 999002 {
+			return "node"
+		}
+		return ""
+	}
+
+	// Single external holder + daemon's own PID.
+	findPortHoldersFn = func(int) []int { return []int{os.Getpid(), 999002} }
+	rec := s.buildPortConflictRecovery(4242)
+	if rec == nil {
+		t.Fatalf("expected recovery for single external holder; got nil")
+	}
+	if rec.Action != "kill_pid" || rec.PID != 999002 {
+		t.Errorf("got action=%q pid=%d; want kill_pid pid=999002", rec.Action, rec.PID)
+	}
+	if !strings.Contains(rec.Message, "node") {
+		t.Errorf("message %q should mention command name", rec.Message)
+	}
+
+	// Multiple external holders → kill_port.
+	findPortHoldersFn = func(int) []int { return []int{999002, 999003, 999004} }
+	rec = s.buildPortConflictRecovery(4242)
+	if rec == nil {
+		t.Fatalf("expected recovery for multi holders; got nil")
+	}
+	if rec.Action != "kill_port" || rec.Port != 4242 {
+		t.Errorf("got action=%q port=%d; want kill_port port=4242", rec.Action, rec.Port)
+	}
+
+	// Only the daemon's own PID → no recovery (transient/false positive).
+	findPortHoldersFn = func(int) []int { return []int{os.Getpid()} }
+	if rec := s.buildPortConflictRecovery(4242); rec != nil {
+		t.Errorf("expected nil recovery when only daemon PID holds the port; got %+v", rec)
+	}
+}
+
+// TestValidateReservePorts covers the validation rules for the reserve_ports
+// vibe.json field: legal name shape, primary/oauth collisions reject, the
+// reserved name "PORT" rejects, range checks bite, and same-port-twice
+// rejects (a single port should have one canonical name in $PORT_<NAME>).
+func TestValidateReservePorts(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		reserve      map[string]int
+		primary      int
+		oauthCB      int
+		want         map[string]int
+		wantErrMatch string
+	}{
+		{name: "empty", reserve: nil, primary: 3012, want: nil},
+		{name: "ok single", reserve: map[string]int{"server": 3001}, primary: 3012, want: map[string]int{"server": 3001}},
+		{name: "ok mixed case lowered", reserve: map[string]int{"Server": 3001}, primary: 3012, want: map[string]int{"server": 3001}},
+		{name: "rejects empty name", reserve: map[string]int{"": 3001}, primary: 3012, wantErrMatch: "empty"},
+		{name: "rejects bad name shape", reserve: map[string]int{"1bad": 3001}, primary: 3012, wantErrMatch: "must match"},
+		{name: "rejects reserved PORT name", reserve: map[string]int{"PORT": 3001}, primary: 3012, wantErrMatch: "reserved"},
+		{name: "rejects primary collision", reserve: map[string]int{"server": 3012}, primary: 3012, wantErrMatch: "primary port"},
+		{name: "rejects oauth collision", reserve: map[string]int{"server": 8787}, primary: 3012, oauthCB: 8787, wantErrMatch: "oauth_callback_port"},
+		{name: "rejects out of range low", reserve: map[string]int{"server": 0}, primary: 3012, wantErrMatch: "out of range"},
+		{name: "rejects out of range high", reserve: map[string]int{"server": 70000}, primary: 3012, wantErrMatch: "out of range"},
+		{name: "rejects same port twice", reserve: map[string]int{"server": 3001, "api": 3001}, primary: 3012, wantErrMatch: "both map to port"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateReservePorts(tc.reserve, tc.primary, tc.oauthCB)
+			if tc.wantErrMatch != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrMatch) {
+					t.Fatalf("err = %v; want error containing %q", err, tc.wantErrMatch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalIntMaps(got, tc.want) {
+				t.Errorf("got %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func equalIntMaps(a, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// TestFindFreePortSkipsReservePorts is the core invariant that prevents the
+// screener.vibe / task-tracker collision from happening at config time:
+// when route A reserves port 3001 via reserve_ports, the auto-assigner must
+// not hand 3001 to route B.
+func TestFindFreePortSkipsReservePorts(t *testing.T) {
+	t.Parallel()
+	table := NewRouteTable()
+	table.Add(&Route{
+		Name:         "screener",
+		Port:         3012,
+		Type:         RouteManaged,
+		ReservePorts:   map[string]int{"server": 3001, "metrics": 3002, "admin": 3000},
+		RegisteredAt: time.Now(),
+	})
+
+	for i := 0; i < 5; i++ {
+		got, err := findFreePort(table)
+		if err != nil {
+			t.Fatalf("findFreePort: %v", err)
+		}
+		if got == 3000 || got == 3001 || got == 3002 || got == 3012 {
+			t.Fatalf("findFreePort returned reserved port %d", got)
+		}
+	}
+}
+
+// TestHandleStartReservePortConflictAttachesRecovery is the screener.vibe
+// regression for the multi-port case: a stale process (e.g. another app's
+// NextAuth) holds one of the route's reserve_ports. Without this, screener's
+// bun server silently fails to bind its named "server" port and Vite's
+// proxy bleeds traffic into the wrong app. With this, the user gets a
+// clear "Kill PID X (node) and retry" recovery — same UX as the primary
+// port case — and the persisted Failure references the offending name.
+func TestHandleStartReservePortConflictAttachesRecovery(t *testing.T) {
+	t.Parallel()
+	s := testServer()
+	s.ReadyTimeout = 2 * time.Second
+
+	// Pick two distinct free ports: one for the route's primary (will be
+	// free), one for a reserve_port (will be held by an external process).
+	ln1, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	primary := ln1.Addr().(*net.TCPAddr).Port
+	ln1.Close()
+
+	ln2, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	reservePort := ln2.Addr().(*net.TCPAddr).Port
+	ln2.Close()
+
+	holder := exec.Command("python3", "-c", fmt.Sprintf(
+		`import signal, http.server, socketserver
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+with socketserver.TCPServer(("127.0.0.1", %d), http.server.BaseHTTPRequestHandler) as s:
+    s.serve_forever()`, reservePort))
+	holder.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := holder.Start(); err != nil {
+		t.Fatalf("start port holder: %v", err)
+	}
+	t.Cleanup(func() {
+		syscall.Kill(-holder.Process.Pid, syscall.SIGKILL)
+		holder.Wait()
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", reservePort), 100*time.Millisecond)
+		if dialErr == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !s.isPortReady(reservePort) {
+		t.Fatalf("port holder never bound port %d", reservePort)
+	}
+
+	route := &Route{
+		Name:         "screener-multi",
+		Port:         primary,
+		ReservePorts:   map[string]int{"server": reservePort},
+		Type:         RouteManaged,
+		Cmd:          "sleep 60",
+		Dir:          t.TempDir(),
+		RegisteredAt: time.Now(),
+	}
+	s.table.Add(route)
+	t.Cleanup(func() { s.table.Remove(route.Name) })
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/_api/routes/%s/start", route.Name), nil)
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d; want 409; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v; body: %s", err, w.Body.String())
+	}
+	errMsg, _ := resp["error"].(string)
+	if !strings.Contains(errMsg, fmt.Sprintf("port %d", reservePort)) {
+		t.Errorf("error %q should reference reserve port %d", errMsg, reservePort)
+	}
+	failureMsg := route.LoadFailure().Message
+	if !strings.Contains(failureMsg, "\"server\"") {
+		t.Errorf("persisted failure message %q should reference the reserve_ports name", failureMsg)
+	}
+	rec, ok := resp["recovery"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected recovery hint; body: %s", w.Body.String())
+	}
+	if rec["action"] != "kill_pid" {
+		t.Errorf("action = %v; want kill_pid", rec["action"])
+	}
+	if int(rec["pid"].(float64)) != holder.Process.Pid {
+		t.Errorf("pid = %v; want %d", rec["pid"], holder.Process.Pid)
+	}
+
+	failure := route.LoadFailure()
+	if failure == nil || failure.Recovery == nil {
+		t.Fatalf("expected route.Failure.Recovery to be persisted for reload survival")
+	}
+	if failure.Recovery.PID != holder.Process.Pid {
+		t.Errorf("persisted pid = %d; want %d", failure.Recovery.PID, holder.Process.Pid)
+	}
 }
 
 // TestWriteStartFailureIncludesRecoveryHint verifies that a StartError whose
@@ -553,6 +907,60 @@ func TestWriteStartFailureIncludesRecoveryHint(t *testing.T) {
 
 // TestHandleStartSafeKillPIDRejectsDaemon ensures the recovery flow can't be
 // used to SIGTERM the daemon's own PID via a crafted kill_pid payload.
+func TestAPINonLocalHostKnownDaemonPathStillHitsDaemonAPI(t *testing.T) {
+	s := testServer()
+	body, _ := json.Marshal(map[string]any{"name": "app", "port": 4444})
+	req := httptest.NewRequest(http.MethodPost, "/_api/routes", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("register status = %d; body: %s", w.Code, w.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/_api/routes", nil)
+	req.Host = "app.test"
+	w = httptest.NewRecorder()
+	s.apiHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"name":"app"`) {
+		t.Fatalf("expected daemon route list JSON, got: %s", w.Body.String())
+	}
+}
+
+func TestAPINonLocalHostUnknownPathProxiesUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_api/configuration" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"upstream":true}`))
+	}))
+	defer upstream.Close()
+
+	s := testServer()
+	s.table.Add(&Route{
+		Name:         "app",
+		Type:         RouteSticky,
+		Port:         testPortFromURL(t, upstream.URL),
+		RegisteredAt: time.Now(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/_api/configuration", nil)
+	req.Host = "app.test"
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != `{"upstream":true}` {
+		t.Fatalf("body = %q; want upstream payload", got)
+	}
+}
+
 func TestHandleStartSafeKillPIDRejectsDaemon(t *testing.T) {
 	t.Parallel()
 	s := testServer()
@@ -579,5 +987,195 @@ func TestHandleStartSafeKillPIDRejectsDaemon(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d; want 400 (refuse self-kill); body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleStopNoAcceptHeaderReturnsJSON guards the CLI fix: handlers used
+// to 303-redirect to https://local.{tld}/ when Accept != "application/json",
+// which the Unix-socket transport can't follow (TLS over unix conn fails),
+// surfacing as a spurious "daemon not running" CLI error. Now we only redirect
+// for actual browser form posts (Content-Type: application/x-www-form-urlencoded),
+// and a CLI-shaped DELETE with no Accept header gets a JSON 200.
+func TestHandleStopNoAcceptHeaderReturnsJSON(t *testing.T) {
+	t.Parallel()
+	s := testServer()
+
+	// Seed a managed route so /stop has a target.
+	s.table.Add(&Route{
+		Name:         "cli-stop",
+		Type:         RouteManaged,
+		Port:         5556,
+		Cmd:          "sleep 60",
+		RegisteredAt: time.Now(),
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/_api/routes/cli-stop/stop", nil)
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+	if loc := w.Header().Get("Location"); loc != "" {
+		t.Errorf("unexpected Location header %q — handler should not redirect for CLI requests", loc)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v; body: %s", err, w.Body.String())
+	}
+	if resp["ok"] != true {
+		t.Errorf("ok = %v; want true; body: %s", resp["ok"], w.Body.String())
+	}
+}
+
+// TestHandleStopBrowserFormStillRedirects ensures the dashboard's form-post
+// path still gets the 303-redirect back to the dashboard.
+func TestHandleStopBrowserFormStillRedirects(t *testing.T) {
+	t.Parallel()
+	s := testServer()
+	s.table.Add(&Route{
+		Name:         "form-stop",
+		Type:         RouteManaged,
+		Port:         5557,
+		Cmd:          "sleep 60",
+		RegisteredAt: time.Now(),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/_api/routes/form-stop/stop", nil)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d; want 303; body: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); !strings.Contains(loc, "local.test") {
+		t.Errorf("Location = %q; want redirect to local.{tld}", loc)
+	}
+}
+
+// TestHandleStartSyncsVibeJSON verifies that an edit to vibe.json (adding
+// oauth_callback_port) takes effect on the next vibe start <name> without
+// requiring deregister + re-register. This was the screener.vibe bug:
+// `startExisting` used to bypass the register flow entirely, so fields the
+// user added to vibe.json after first registration never made it onto the
+// route.
+func TestHandleStartSyncsVibeJSON(t *testing.T) {
+	// Not t.Parallel: this test takes a free TCP port and probes the OAuth
+	// bridge bind, which races with other parallel tests grabbing random ports.
+	s := testServer()
+
+	dir := t.TempDir()
+
+	// Pick a free port for the OAuth bridge so the bind probe in
+	// validateOAuthBridgeConfig succeeds regardless of what else is running
+	// on the dev machine.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	cbPort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	// Initial vibe.json with no oauth_callback_port.
+	initial := []byte(`{"name":"sync-target","cmd":"sleep 60"}`)
+	if err := os.WriteFile(filepath.Join(dir, "vibe.json"), initial, 0644); err != nil {
+		t.Fatalf("write vibe.json: %v", err)
+	}
+
+	// Register the route the way the CLI does on first start.
+	s.table.Add(&Route{
+		Name:         "sync-target",
+		Type:         RouteManaged,
+		Port:         5558,
+		Cmd:          "sleep 60",
+		Dir:          dir,
+		RegisteredAt: time.Now(),
+	})
+
+	// User edits vibe.json after registration to add an oauth_callback_port.
+	updated := fmt.Appendf(nil, `{"name":"sync-target","cmd":"sleep 60","oauth_callback_port":%d}`, cbPort)
+	if err := os.WriteFile(filepath.Join(dir, "vibe.json"), updated, 0644); err != nil {
+		t.Fatalf("update vibe.json: %v", err)
+	}
+
+	// Call the sync path directly — handleStart calls this before procs.Start,
+	// so we don't have to actually spawn anything to verify the field updates.
+	if err := s.syncRouteFromVibeJSON(s.mustGet(t, "sync-target")); err != nil {
+		t.Fatalf("syncRouteFromVibeJSON: %v", err)
+	}
+	got := s.mustGet(t, "sync-target")
+	if got.OAuthCallbackPort != cbPort {
+		t.Errorf("OAuthCallbackPort = %d; want %d (vibe.json edit should have synced)", got.OAuthCallbackPort, cbPort)
+	}
+	t.Cleanup(func() { s.stopOAuthBridgeListeners() })
+}
+
+// TestSyncRouteFromVibeJSONIgnoresWrongName confirms we don't cross-pollinate
+// fields when vibe.json's name disagrees with the route — the user is probably
+// running `vibe start <other>` from the wrong directory.
+func TestSyncRouteFromVibeJSONIgnoresWrongName(t *testing.T) {
+	t.Parallel()
+	s := testServer()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "vibe.json"),
+		[]byte(`{"name":"different","cmd":"sleep 60","oauth_callback_port":9999}`), 0644); err != nil {
+		t.Fatalf("write vibe.json: %v", err)
+	}
+	r := &Route{Name: "victim", Type: RouteManaged, Cmd: "true", Dir: dir, Port: 5559, RegisteredAt: time.Now()}
+	s.table.Add(r)
+	if err := s.syncRouteFromVibeJSON(r); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if r.OAuthCallbackPort != 0 {
+		t.Errorf("OAuthCallbackPort = %d; want 0 (mismatched name should be ignored)", r.OAuthCallbackPort)
+	}
+}
+
+func (s *Server) mustGet(t *testing.T, name string) *Route {
+	t.Helper()
+	r, ok := s.table.Get(name)
+	if !ok {
+		t.Fatalf("route %q not in table", name)
+	}
+	return r
+}
+
+// TestStickyRoundTripPreservesOAuthCallback guards a real daemon-restart bug:
+// stickyEntry was missing OAuthCallbackPort entirely, so a managed route's
+// callback bridge config was silently dropped on every save and never restored
+// on load. Reproduces by saving + loading a round trip through the same dir.
+func TestStickyRoundTripPreservesOAuthCallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	tab := NewRouteTable()
+	tab.Add(&Route{
+		Name:              "rt",
+		Type:              RouteManaged,
+		Port:              5560,
+		Cmd:               "true",
+		OAuthCallbackPort: 8789,
+		ReservePorts:      map[string]int{"server": 5561},
+		RegisteredAt:      time.Now(),
+	})
+	if err := saveStickyRoutes(tab, dir); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded := NewRouteTable()
+	if err := loadStickyRoutes(loaded, dir); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	r, ok := loaded.Get("rt")
+	if !ok {
+		t.Fatal("route missing after load")
+	}
+	if r.OAuthCallbackPort != 8789 {
+		t.Errorf("OAuthCallbackPort = %d; want 8789 (round-trip lost the field)", r.OAuthCallbackPort)
+	}
+	if r.ReservePorts["server"] != 5561 {
+		t.Errorf("ReservePorts[server] = %d; want 5561", r.ReservePorts["server"])
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -41,15 +41,21 @@ type Server struct {
 	tlsCert *tls.Certificate
 	caCert  *x509.Certificate
 	caKey   *ecdsa.PrivateKey
+
+	oauthBridgeMu        sync.Mutex
+	oauthBridgeServers   map[int]*http.Server
+	oauthBridgeListeners map[int]net.Listener
 }
 
 // NewServer creates a daemon server with the given configuration.
 func NewServer(cfg *config.Config) *Server {
 	return &Server{
-		cfg:   cfg,
-		table: NewRouteTable(),
-		procs: NewProcessManager(),
-		quit:  make(chan struct{}),
+		cfg:                  cfg,
+		table:                NewRouteTable(),
+		procs:                NewProcessManager(),
+		quit:                 make(chan struct{}),
+		oauthBridgeServers:   make(map[int]*http.Server),
+		oauthBridgeListeners: make(map[int]net.Listener),
 	}
 }
 
@@ -62,6 +68,9 @@ func (s *Server) Start() error {
 
 	if err := loadStickyRoutes(s.table, s.configDir()); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not load persisted routes: %v\n", err)
+	}
+	if err := s.reconcileOAuthBridgeListeners(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not start oauth callback bridge listeners: %v\n", err)
 	}
 
 	s.startedAt = time.Now()
@@ -110,6 +119,7 @@ func (s *Server) Stop() {
 	if s.httpsSrv != nil {
 		_ = s.httpsSrv.Shutdown(ctx)
 	}
+	s.stopOAuthBridgeListeners()
 	_ = os.Remove(s.cfg.Daemon.Socket)
 	_ = os.Remove(fmt.Sprintf("%s/daemon.pid", config.Dir()))
 }
@@ -357,6 +367,9 @@ func findFreePort(table *RouteTable) (int, error) {
 	for _, r := range table.List() {
 		if r.Port > 0 {
 			claimed[r.Port] = true
+		}
+		if r.OAuthCallbackPort > 0 {
+			claimed[r.OAuthCallbackPort] = true
 		}
 	}
 	for port := 3000; port < 4000; port++ {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -264,20 +264,24 @@ func (s *Server) routeRequest(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, route.ExternalURL, http.StatusTemporaryRedirect)
 				return
 			}
-			// If the registered port isn't answering, pick the right failure UI.
-			// A managed route whose child process is gone → the "Stopped" start
-			// page with a Start button (unchanged). Anything else (including a
-			// managed route whose child rebound to a different port) → the
-			// repair page, which will try to auto-discover the new port.
+			// Managed routes must never proxy when the route is marked stopped,
+			// even if another process is now listening on the old port.
+			if route.Type == RouteManaged {
+				pid, hasPID := route.PIDValue()
+				if !route.Running.Load() || !hasPID || !processAlive(pid) {
+					route.Running.Store(false)
+					route.Ready.Store(false)
+					if hasPID && !processAlive(pid) {
+						route.ClearPID()
+					}
+					s.serveStartPage(w, r, route)
+					return
+				}
+			}
+			// If the registered port isn't answering, use the repair page for
+			// running managed routes (and other non-bookmark routes).
 			if !s.isPortReady(route.Port) {
 				route.Ready.Store(false)
-				if route.Type == RouteManaged {
-					pid, hasPID := route.PIDValue()
-					if !hasPID || !processAlive(pid) {
-						s.serveStartPage(w, r, route)
-						return
-					}
-				}
 				s.serveRepairPage(w, r, route)
 				return
 			}
@@ -332,6 +336,83 @@ func (s *Server) killPort(port int) {
 	}
 }
 
+// findPortHolders runs `lsof -ti tcp:PORT` and returns the listening PIDs.
+// Returns nil on lsof error or when no process is bound to the port.
+var findPortHoldersFn = findPortHoldersDefault
+
+func findPortHoldersDefault(port int) []int {
+	out, err := exec.Command("lsof", "-ti", fmt.Sprintf("tcp:%d", port)).Output()
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		var pid int
+		if _, err := fmt.Sscan(line, &pid); err == nil && pid > 0 {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+// pidCommand returns a short command name for a pid via `ps -p PID -o comm=`.
+// Best-effort: returns "" on error or empty output.
+var pidCommandFn = pidCommandDefault
+
+func pidCommandDefault(pid int) string {
+	out, err := exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "comm=").Output()
+	if err != nil {
+		return ""
+	}
+	cmd := strings.TrimSpace(string(out))
+	// `ps -o comm=` returns the full path on macOS; trim to the basename for
+	// readability in the recovery message.
+	if i := strings.LastIndex(cmd, "/"); i >= 0 {
+		cmd = cmd[i+1:]
+	}
+	return cmd
+}
+
+// buildPortConflictRecovery builds a Recovery hint for a "port already in use"
+// situation by inspecting which process is holding the port. Filters out the
+// daemon itself and any PID currently owned by another managed route (those
+// should be stopped via the route's Stop handler, not signaled directly).
+//
+// Returns nil if the port is no longer held by any external process — the
+// caller should treat that as a transient condition and not surface a hint.
+func (s *Server) buildPortConflictRecovery(port int) *Recovery {
+	pids := findPortHoldersFn(port)
+	myPID := os.Getpid()
+	external := make([]int, 0, len(pids))
+	for _, pid := range pids {
+		if pid == myPID {
+			continue
+		}
+		if s.procs.OwnsPID(pid) {
+			continue
+		}
+		external = append(external, pid)
+	}
+	if len(external) == 0 {
+		return nil
+	}
+	if len(external) == 1 {
+		pid := external[0]
+		cmd := pidCommandFn(pid)
+		msg := fmt.Sprintf("Port %d is held by PID %d", port, pid)
+		if cmd != "" {
+			msg += fmt.Sprintf(" (%s)", cmd)
+		}
+		msg += ". Kill it and retry?"
+		return &Recovery{Action: "kill_pid", PID: pid, Message: msg}
+	}
+	return &Recovery{
+		Action:  "kill_port",
+		Port:    port,
+		Message: fmt.Sprintf("Port %d is held by %d processes. Kill them all and retry?", port, len(external)),
+	}
+}
+
 func (s *Server) configDir() string {
 	if s.ConfigDir != "" {
 		return s.ConfigDir
@@ -370,6 +451,11 @@ func findFreePort(table *RouteTable) (int, error) {
 		}
 		if r.OAuthCallbackPort > 0 {
 			claimed[r.OAuthCallbackPort] = true
+		}
+		for _, p := range r.ReservePorts {
+			if p > 0 {
+				claimed[p] = true
+			}
 		}
 	}
 	for port := 3000; port < 4000; port++ {

--- a/internal/daemon/dashboard.go
+++ b/internal/daemon/dashboard.go
@@ -290,7 +290,7 @@ func (s *Server) serveDashboard(w http.ResponseWriter, r *http.Request) {
 		safeName := html.EscapeString(r.Name)
 		vibeURL := fmt.Sprintf("%s://%s.%s", scheme, safeName, tld)
 
-		isStopped := r.Type == RouteManaged && !s.isPortReady(r.Port) && !r.Running.Load()
+		isStopped := r.Type == RouteManaged && !r.Running.Load()
 
 		// Secondary URL display
 		urlDisplay := fmt.Sprintf("%s.%s", safeName, tld)
@@ -313,7 +313,7 @@ func (s *Server) serveDashboard(w http.ResponseWriter, r *http.Request) {
 		// Action buttons
 		actionHTML := ""
 		editSVG := `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z"/></svg>`
-		if r.Type == RouteManaged && s.isPortReady(r.Port) {
+		if r.Type == RouteManaged && r.Running.Load() {
 			actionHTML = fmt.Sprintf(`<button class="btn" onclick="routeAction(this,'%s','stop')">Stop</button>`, safeName)
 		} else if r.Type == RouteManaged {
 			actionHTML = fmt.Sprintf(`<button class="btn btn-primary" onclick="routeAction(this,'%s','start')">Start</button>`, safeName)
@@ -408,7 +408,7 @@ func (s *Server) serveDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Stopped state — dim icon only, not text
-		isStopped := r.Type == RouteManaged && !s.isPortReady(r.Port) && !r.Running.Load()
+		isStopped := r.Type == RouteManaged && !r.Running.Load()
 		tileClass := "grid-tile"
 		if isStopped {
 			tileClass = "grid-tile tile-stopped"

--- a/internal/daemon/dashboard.go
+++ b/internal/daemon/dashboard.go
@@ -444,49 +444,60 @@ Or open in a browser: %[2]s://local.%[1]s/setup.md</textarea>
 <!-- Add/Edit Modal -->
 <div class="modal-overlay" id="modal-overlay" onclick="if(event.target===this)closeModal()">
 <div class="modal">
-  <h3 id="modal-title">Add Route</h3>
-  <div class="type-toggle" id="type-toggle">
-    <button id="toggle-local" class="active" onclick="setRouteType('local')">Local Port</button>
-    <button id="toggle-bookmark" onclick="setRouteType('bookmark')">External URL</button>
+  <div class="modal-header">
+    <button type="button" class="icon-trigger" id="icon-preview" onclick="toggleIconPopover('route-popover',event)" title="Change icon">?</button>
+    <div class="modal-header-text">
+      <div class="modal-eyebrow" id="modal-title">Add Route</div>
+      <h3 id="modal-heading">New route</h3>
+      <div class="modal-sub" id="modal-sub">Map a friendly .vibe name to a local port or external URL.</div>
+    </div>
   </div>
-  <div style="margin-bottom:16px">
-    <label for="route-name">Name</label>
-    <input id="route-name" type="text" placeholder="myapp" autocomplete="off">
-  </div>
-  <div id="port-field" style="margin-bottom:16px">
-    <label for="route-port">Port</label>
-    <input id="route-port" type="number" placeholder="3000">
-  </div>
-  <div id="url-field" style="display:none;margin-bottom:16px">
-    <label for="route-url">URL</label>
-    <input id="route-url" type="text" placeholder="example.com:8080">
-  </div>
-  <div id="proxy-field" style="display:none;margin-bottom:12px">
-    <label class="checkbox-row">
-      <input id="route-proxy" type="checkbox" onchange="onProxyToggle()">
-      <span>Proxy instead of redirect</span>
-    </label>
-    <p class="hint">Keep <code>.vibe</code> in the browser URL. Useful for mirroring Tailscale / intranet hosts on a friendly name.</p>
-  </div>
-  <div id="insecure-field" style="display:none;margin-bottom:16px">
-    <label class="checkbox-row">
-      <input id="route-insecure" type="checkbox">
-      <span>Allow self-signed TLS cert</span>
-    </label>
-    <p class="hint">Only enable when the upstream uses an untrusted certificate (e.g. Tailscale MagicDNS).</p>
-  </div>
-  <div style="margin-bottom:16px">
-    <label>Icon</label>
+  <div class="icon-popover" id="route-popover">
     <input id="route-icon" type="hidden">
-    <div class="icon-select-row">
-      <div class="icon-preview icon-preview-lg" id="icon-preview">?</div>
-      <input id="route-icon-custom" type="text" class="icon-custom-input" placeholder="Type emoji" oninput="onCustomIcon('route-icon','icon-preview','icon-clear','icon-picker')">
+    <div class="icon-popover-row">
+      <input id="route-icon-custom" type="text" placeholder="Paste any emoji…" oninput="onCustomIcon('route-icon','icon-preview','icon-clear','icon-picker')">
       <button type="button" class="btn btn-sm" id="icon-clear" onclick="clearIcon('route-icon','icon-preview','icon-clear','icon-picker')" style="display:none">Clear</button>
     </div>
     <div class="icon-picker" id="icon-picker"></div>
   </div>
+  <div class="modal-body">
+    <div class="type-toggle" id="type-toggle">
+      <button id="toggle-local" class="active" onclick="setRouteType('local')">Local Port</button>
+      <button id="toggle-bookmark" onclick="setRouteType('bookmark')">External URL</button>
+    </div>
+    <div class="field-row">
+      <div class="field">
+        <label for="route-name">Name</label>
+        <input id="route-name" type="text" placeholder="myapp" autocomplete="off" oninput="updateModalHeading()">
+      </div>
+      <div id="port-field" class="field field-port">
+        <label for="route-port">Port</label>
+        <input id="route-port" type="number" placeholder="3000">
+      </div>
+    </div>
+    <div id="url-field" class="field" style="display:none">
+      <label for="route-url">URL</label>
+      <input id="route-url" type="text" placeholder="example.com:8080">
+    </div>
+    <div id="options-card" class="options-card" style="display:none">
+      <div id="proxy-field" class="opt">
+        <label class="checkbox-row">
+          <input id="route-proxy" type="checkbox" onchange="onProxyToggle()">
+          <span>Proxy instead of redirect</span>
+        </label>
+        <p class="hint">Keep <code>.vibe</code> in the browser URL. Useful for mirroring Tailscale or intranet hosts on a friendly name.</p>
+      </div>
+      <div id="insecure-field" class="opt" style="display:none">
+        <label class="checkbox-row">
+          <input id="route-insecure" type="checkbox">
+          <span>Allow self-signed TLS cert</span>
+        </label>
+        <p class="hint">Only enable when the upstream uses an untrusted certificate (e.g. Tailscale MagicDNS).</p>
+      </div>
+    </div>
+  </div>
   <div class="modal-actions">
-    <button class="btn btn-danger" id="modal-delete" style="display:none;margin-right:auto" onclick="deleteRoute()">Delete</button>
+    <button class="btn btn-danger" id="modal-delete" style="display:none;margin-right:auto" onclick="deleteRoute()">Delete route</button>
     <button class="btn" onclick="closeModal()">Cancel</button>
     <button class="btn-add" id="modal-save" onclick="saveRoute()">Add</button>
   </div>
@@ -495,26 +506,35 @@ Or open in a browser: %[2]s://local.%[1]s/setup.md</textarea>
 <!-- Managed Route Settings Modal -->
 <div class="modal-overlay" id="managed-overlay" onclick="if(event.target===this)closeManagedModal()">
 <div class="modal">
-  <h3>Route Settings</h3>
-  <div style="margin-bottom:16px">
-    <label for="managed-name">Name</label>
-    <input id="managed-name" type="text" placeholder="myapp" autocomplete="off">
+  <div class="modal-header">
+    <button type="button" class="icon-trigger" id="managed-icon-preview" onclick="toggleIconPopover('managed-popover',event)" title="Change icon">?</button>
+    <div class="modal-header-text">
+      <div class="modal-eyebrow">Managed Route</div>
+      <h3 id="managed-heading">Settings</h3>
+      <div class="modal-sub">Configure a daemon-managed process.</div>
+    </div>
   </div>
-  <div style="margin-bottom:16px">
-    <label>Icon</label>
+  <div class="icon-popover" id="managed-popover">
     <input id="managed-icon" type="hidden">
-    <div class="icon-select-row">
-      <div class="icon-preview icon-preview-lg" id="managed-icon-preview">?</div>
-      <input id="managed-icon-custom" type="text" class="icon-custom-input" placeholder="Type emoji" oninput="onCustomIcon('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker')">
+    <div class="icon-popover-row">
+      <input id="managed-icon-custom" type="text" placeholder="Paste any emoji…" oninput="onCustomIcon('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker')">
       <button type="button" class="btn btn-sm" id="managed-icon-clear" onclick="clearIcon('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker')" style="display:none">Clear</button>
     </div>
     <div class="icon-picker" id="managed-icon-picker"></div>
   </div>
-  <label for="idle-timeout">Auto-stop after idle (minutes)</label>
-  <input id="idle-timeout" type="number" min="0" placeholder="0 = never">
-  <p class="hint">Stop the process automatically when no traffic is received. Set to 0 to disable.</p>
+  <div class="modal-body">
+    <div class="field">
+      <label for="managed-name">Name</label>
+      <input id="managed-name" type="text" placeholder="myapp" autocomplete="off" oninput="updateManagedHeading()">
+    </div>
+    <div class="field">
+      <label for="idle-timeout">Auto-stop after idle (minutes)</label>
+      <input id="idle-timeout" type="number" min="0" placeholder="0 = never">
+      <p class="hint">Stop the process automatically when no traffic is received. Set to <code>0</code> to disable.</p>
+    </div>
+  </div>
   <div class="modal-actions">
-    <button class="btn btn-danger" style="margin-right:auto" onclick="deleteManagedRoute()">Delete</button>
+    <button class="btn btn-danger" style="margin-right:auto" onclick="deleteManagedRoute()">Delete route</button>
     <button class="btn" onclick="closeManagedModal()">Cancel</button>
     <button class="btn-add" onclick="saveManagedSettings()">Save</button>
   </div>
@@ -533,22 +553,47 @@ function setView(mode,save){
 var modalMode='add';
 var editingName='';
 function setRouteType(t){
+  var modal=document.querySelector('#modal-overlay .modal');
+  var animate=modal&&document.getElementById('modal-overlay').classList.contains('active');
+  var fromH=animate?modal.offsetHeight:0;
   document.getElementById('toggle-local').className=t==='local'?'active':'';
   document.getElementById('toggle-bookmark').className=t==='bookmark'?'active':'';
   document.getElementById('port-field').style.display=t==='local'?'':'none';
   document.getElementById('url-field').style.display=t==='bookmark'?'':'none';
   document.getElementById('proxy-field').style.display=t==='bookmark'?'':'none';
+  document.getElementById('options-card').style.display=t==='bookmark'?'':'none';
   onProxyToggle();
+  if(animate){
+    var toH=modal.offsetHeight;
+    if(toH!==fromH){
+      modal.style.transition='none';
+      modal.style.height=fromH+'px';
+      modal.offsetHeight;
+      modal.style.transition='height .3s cubic-bezier(.4,0,.2,1)';
+      modal.style.height=toH+'px';
+      setTimeout(function(){modal.style.transition='';modal.style.height=''},320);
+    }
+  }
 }
 function onProxyToggle(){
   var proxyOn=document.getElementById('route-proxy').checked;
   var bookmark=document.getElementById('toggle-bookmark').className==='active';
   document.getElementById('insecure-field').style.display=(bookmark&&proxyOn)?'':'none';
 }
+function updateModalHeading(){
+  var n=document.getElementById('route-name').value.trim();
+  document.getElementById('modal-heading').textContent=n?n+'.vibe':(modalMode==='edit'?'Edit route':'New route');
+}
+function updateManagedHeading(){
+  var n=document.getElementById('managed-name').value.trim();
+  document.getElementById('managed-heading').textContent=n?n+'.vibe':'Settings';
+}
 function openAddModal(){
   modalMode='add';editingName='';
   document.getElementById('modal-title').textContent='Add Route';
-  document.getElementById('modal-save').textContent='Add';
+  document.getElementById('modal-heading').textContent='New route';
+  document.getElementById('modal-sub').textContent='Map a friendly .vibe name to a local port or external URL.';
+  document.getElementById('modal-save').textContent='Add Route';
   document.getElementById('modal-delete').style.display='none';
   document.getElementById('type-toggle').style.display='';
   document.getElementById('route-name').value='';
@@ -564,6 +609,8 @@ function openAddModal(){
 function openEditModal(name,port,url,type,icon,autoIcon,proxy,insecure){
   modalMode='edit';editingName=name;
   document.getElementById('modal-title').textContent='Edit Route';
+  document.getElementById('modal-heading').textContent=name+'.vibe';
+  document.getElementById('modal-sub').textContent=type==='bookmark'?'Reverse-proxy or redirect to an external host.':'Forward .vibe traffic to a local port.';
   document.getElementById('modal-save').textContent='Save';
   document.getElementById('modal-delete').style.display='';
   document.getElementById('type-toggle').style.display='';
@@ -584,14 +631,12 @@ function openEditModal(name,port,url,type,icon,autoIcon,proxy,insecure){
   }
   document.getElementById('modal-overlay').classList.add('active');
 }
-function closeModal(){document.getElementById('modal-overlay').classList.remove('active')}
+function closeModal(){document.getElementById('modal-overlay').classList.remove('active');closeAllIconPopovers()}
 function saveRoute(){
   var name=document.getElementById('route-name').value.trim();
   if(!name)return;
   var isBookmark=document.getElementById('toggle-bookmark').className==='active';
-  var body={name:name};
-  var icon=getIconValue('route-icon');
-  if(icon)body.icon=icon;
+  var body={name:name,icon:getIconValue('route-icon')};
   if(isBookmark){
     var u=document.getElementById('route-url').value.trim();
     if(!u)return;
@@ -631,13 +676,14 @@ function copyText(){
 var managedEditName='';
 function openManagedModal(name,idle,icon,autoIcon){
   managedEditName=name;
+  document.getElementById('managed-heading').textContent=name+'.vibe';
   document.getElementById('managed-name').value=name;
   document.getElementById('idle-timeout').value=idle||'';
   document.getElementById('managed-icon').dataset.autoicon=autoIcon||'';
   setIconField('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker',icon||'',autoIcon||'');
   document.getElementById('managed-overlay').classList.add('active');
 }
-function closeManagedModal(){document.getElementById('managed-overlay').classList.remove('active')}
+function closeManagedModal(){document.getElementById('managed-overlay').classList.remove('active');closeAllIconPopovers()}
 function deleteManagedRoute(){
   if(!managedEditName)return;
   fetch('/_api/routes/'+encodeURIComponent(managedEditName),{method:'DELETE',headers:{'Accept':'application/json'}}).then(function(){location.reload()});
@@ -646,9 +692,7 @@ function saveManagedSettings(){
   var name=document.getElementById('managed-name').value.trim();
   if(!name)return;
   var idle=parseInt(document.getElementById('idle-timeout').value)||0;
-  var icon=getIconValue('managed-icon');
-  var body={name:name,idle_timeout:idle};
-  if(icon)body.icon=icon;
+  var body={name:name,idle_timeout:idle,icon:getIconValue('managed-icon')};
   fetch('/_api/routes/'+encodeURIComponent(managedEditName),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(function(){location.reload()});
 }
 function setIconField(inputId,previewId,clearId,pickerId,val,autoIcon){
@@ -673,7 +717,7 @@ function onCustomIcon(inputId,previewId,clearId,pickerId){
   setIconField(inputId,previewId,clearId,pickerId,val);
 }
 var iconChoices=['🚀','🤖','📦','⚡','🔮','🎯','🛠️','💎','🧪','🌐','📡','🎨','🔒','🗂️','📊','🧩'];
-function buildPicker(containerId,inputId,previewId,clearId){
+function buildPicker(containerId,inputId,previewId,clearId,popoverId){
   var c=document.getElementById(containerId);
   c.innerHTML='';
   iconChoices.forEach(function(em){
@@ -681,16 +725,32 @@ function buildPicker(containerId,inputId,previewId,clearId){
     b.type='button';b.className='icon-pick';b.textContent=em;
     b.onclick=function(){
       setIconField(inputId,previewId,clearId,containerId,em);
+      if(popoverId)closeIconPopover(popoverId);
     };
     c.appendChild(b);
   });
 }
+function toggleIconPopover(id,e){
+  if(e){e.stopPropagation()}
+  var p=document.getElementById(id);
+  var wasOpen=p.classList.contains('active');
+  closeAllIconPopovers();
+  if(!wasOpen)p.classList.add('active');
+}
+function closeIconPopover(id){document.getElementById(id).classList.remove('active')}
+function closeAllIconPopovers(){
+  document.querySelectorAll('.icon-popover.active').forEach(function(p){p.classList.remove('active')});
+}
+document.addEventListener('click',function(e){
+  if(e.target.closest('.icon-popover')||e.target.closest('.icon-trigger'))return;
+  closeAllIconPopovers();
+});
 function highlightPicker(containerId,val){
   var btns=document.getElementById(containerId).querySelectorAll('.icon-pick');
   btns.forEach(function(b){b.classList.toggle('selected',b.textContent===val)});
 }
-buildPicker('icon-picker','route-icon','icon-preview','icon-clear');
-buildPicker('managed-icon-picker','managed-icon','managed-icon-preview','managed-icon-clear');
+buildPicker('icon-picker','route-icon','icon-preview','icon-clear','route-popover');
+buildPicker('managed-icon-picker','managed-icon','managed-icon-preview','managed-icon-clear','managed-popover');
 
 function setIconPreviewEl(el,val){
   if(!val){el.textContent='?';el.style.backgroundImage='';return}

--- a/internal/daemon/log_scan.go
+++ b/internal/daemon/log_scan.go
@@ -11,7 +11,7 @@ import (
 // or Port to offer a one-click "kill and retry" button.
 type Recovery struct {
 	Message string `json:"message"`
-	Action  string `json:"action"` // "kill_pid" | "kill_port"
+	Action  string `json:"action"` // "kill_pid" | "kill_port" | "restart"
 	PID     int    `json:"pid,omitempty"`
 	Port    int    `json:"port,omitempty"`
 }

--- a/internal/daemon/log_scan.go
+++ b/internal/daemon/log_scan.go
@@ -4,16 +4,18 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // Recovery is an actionable hint extracted from a failed managed process's
-// log tail. The dashboard surfaces Message to the user and uses Action + PID
-// or Port to offer a one-click "kill and retry" button.
+// log tail. The dashboard surfaces Message to the user and uses Action +
+// (PID|Port|SuggestedCmd) to offer a one-click remediation button.
 type Recovery struct {
-	Message string `json:"message"`
-	Action  string `json:"action"` // "kill_pid" | "kill_port" | "restart"
-	PID     int    `json:"pid,omitempty"`
-	Port    int    `json:"port,omitempty"`
+	Message      string `json:"message"`
+	Action       string `json:"action"` // "kill_pid" | "kill_port" | "restart" | "edit_cmd" | "info"
+	PID          int    `json:"pid,omitempty"`
+	Port         int    `json:"port,omitempty"`
+	SuggestedCmd string `json:"suggested_cmd,omitempty"`
 }
 
 type recoveryPattern struct {
@@ -58,12 +60,88 @@ var recoveryPatterns = []recoveryPattern{
 	},
 }
 
+// pythonNotFoundRe matches shell errors from invoking a missing `python`
+// interpreter. macOS no longer ships /usr/bin/python — projects that hard-code
+// `python` in their command crash here while `python3` works fine.
+//
+// Examples:
+//
+//	zsh:1: command not found: python
+//	bash: python: command not found
+//	/bin/sh: python: command not found
+var pythonNotFoundRe = regexp.MustCompile(`(?m)(?:command not found:\s*python|python:\s*command not found)\b`)
+
+// moduleNotFoundRe extracts the missing package name from Python's
+// ModuleNotFoundError. Example:
+//
+//	ModuleNotFoundError: No module named 'flask'
+var moduleNotFoundRe = regexp.MustCompile(`ModuleNotFoundError:\s+No module named\s+['"]([a-zA-Z_][a-zA-Z0-9_.]*)['"]`)
+
+// pythonTokenRe finds a standalone `python` token (word-boundary on both sides,
+// not preceded by `python`-suffix chars like `3` or `2`). Used to rewrite
+// `python app.py` → `python3 app.py` without mangling `python3`, `pythonw`,
+// or paths like `/usr/bin/python`.
+var pythonTokenRe = regexp.MustCompile(`(^|[\s;&|"'` + "`" + `])python(\b)`)
+
+// suggestPython3Cmd rewrites the first standalone `python` in cmd to `python3`.
+// Returns (newCmd, true) if a rewrite happened, (cmd, false) otherwise.
+//
+// Skips the rewrite when cmd already contains `python3` — the user has been
+// explicit, and another bare `python` somewhere later (rare) probably means
+// something else.
+func suggestPython3Cmd(cmd string) (string, bool) {
+	if cmd == "" {
+		return cmd, false
+	}
+	if strings.Contains(cmd, "python3") {
+		return cmd, false
+	}
+	if !pythonTokenRe.MatchString(cmd) {
+		return cmd, false
+	}
+	// Rewrite only the first match so we don't accidentally double-rewrite
+	// in pathological inputs.
+	replaced := false
+	out := pythonTokenRe.ReplaceAllStringFunc(cmd, func(m string) string {
+		if replaced {
+			return m
+		}
+		replaced = true
+		return pythonTokenRe.ReplaceAllString(m, "${1}python3${2}")
+	})
+	return out, replaced
+}
+
 // scanLogForRecovery inspects the tail of a failed process's log output and
-// returns a recovery hint if one of the known patterns matches.
-func scanLogForRecovery(tail string) *Recovery {
+// returns a recovery hint if one of the known patterns matches. The route's
+// current cmd is consulted for cmd-rewrite suggestions (e.g. python → python3);
+// pass an empty string when no cmd is available.
+func scanLogForRecovery(tail, cmd string) *Recovery {
 	if tail == "" {
 		return nil
 	}
+
+	// Cmd-aware patterns first — they offer the most direct fix.
+	if pythonNotFoundRe.MatchString(tail) {
+		if newCmd, ok := suggestPython3Cmd(cmd); ok {
+			return &Recovery{
+				Action:       "edit_cmd",
+				Message:      "`python` is not on PATH but `python3` is. Switch the command to use `python3` and retry?",
+				SuggestedCmd: newCmd,
+			}
+		}
+	}
+	if m := moduleNotFoundRe.FindStringSubmatch(tail); len(m) >= 2 {
+		mod := m[1]
+		return &Recovery{
+			Action: "info",
+			Message: fmt.Sprintf(
+				"Missing Python module `%s`. Install it (e.g. `pip3 install %s`, or activate your project's venv) and retry.",
+				mod, mod,
+			),
+		}
+	}
+
 	for _, p := range recoveryPatterns {
 		m := p.re.FindStringSubmatch(tail)
 		if len(m) < 2 {

--- a/internal/daemon/log_scan_test.go
+++ b/internal/daemon/log_scan_test.go
@@ -4,11 +4,14 @@ import "testing"
 
 func TestScanLogForRecovery(t *testing.T) {
 	cases := []struct {
-		name       string
-		tail       string
-		wantAction string
-		wantPID    int
-		wantPort   int
+		name        string
+		tail        string
+		cmd         string
+		wantAction  string
+		wantPID     int
+		wantPort    int
+		wantSugCmd  string
+		wantSubstr  string // optional: must appear in Message
 	}{
 		{
 			name: "nextjs-orphan-pid",
@@ -43,10 +46,44 @@ func TestScanLogForRecovery(t *testing.T) {
 			tail:       ``,
 			wantAction: "",
 		},
+		{
+			name:       "python-not-found-zsh",
+			tail:       `zsh:1: command not found: python`,
+			cmd:        "python app.py",
+			wantAction: "edit_cmd",
+			wantSugCmd: "python3 app.py",
+			wantSubstr: "python3",
+		},
+		{
+			name:       "python-not-found-bash",
+			tail:       `bash: python: command not found`,
+			cmd:        "python -m http.server 8000",
+			wantAction: "edit_cmd",
+			wantSugCmd: "python3 -m http.server 8000",
+		},
+		{
+			name:       "python-not-found-but-cmd-already-python3",
+			tail:       `zsh:1: command not found: python`,
+			cmd:        "python3 app.py",
+			wantAction: "",
+		},
+		{
+			name:       "python-not-found-no-cmd",
+			tail:       `zsh:1: command not found: python`,
+			cmd:        "",
+			wantAction: "",
+		},
+		{
+			name:       "module-not-found",
+			tail:       `Traceback (most recent call last):` + "\n" + `  File "/x/app.py", line 6, in <module>` + "\n" + `    from flask import Flask` + "\n" + `ModuleNotFoundError: No module named 'flask'`,
+			cmd:        "python3 app.py",
+			wantAction: "info",
+			wantSubstr: "flask",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := scanLogForRecovery(tc.tail)
+			got := scanLogForRecovery(tc.tail, tc.cmd)
 			if tc.wantAction == "" {
 				if got != nil {
 					t.Fatalf("expected no recovery, got %+v", got)
@@ -65,9 +102,53 @@ func TestScanLogForRecovery(t *testing.T) {
 			if got.Port != tc.wantPort {
 				t.Errorf("port = %d; want %d", got.Port, tc.wantPort)
 			}
+			if tc.wantSugCmd != "" && got.SuggestedCmd != tc.wantSugCmd {
+				t.Errorf("suggested_cmd = %q; want %q", got.SuggestedCmd, tc.wantSugCmd)
+			}
 			if got.Message == "" {
 				t.Error("message is empty")
 			}
+			if tc.wantSubstr != "" {
+				if !contains(got.Message, tc.wantSubstr) {
+					t.Errorf("message %q missing substring %q", got.Message, tc.wantSubstr)
+				}
+			}
 		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestSuggestPython3Cmd(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"python app.py", "python3 app.py", true},
+		{"python -m http.server", "python3 -m http.server", true},
+		{"  python app.py  ", "  python3 app.py  ", true},
+		{"python3 app.py", "python3 app.py", false},      // already python3
+		{"pythonw app.py", "pythonw app.py", false},      // word-boundary stops match
+		{"node app.js", "node app.js", false},            // no python
+		{"", "", false},                                  // empty
+		{"/usr/bin/python app.py", "/usr/bin/python app.py", false}, // paths kept as-is (not safe to rewrite)
+	}
+	for _, tc := range cases {
+		got, ok := suggestPython3Cmd(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("suggestPython3Cmd(%q) = (%q, %v); want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
 	}
 }

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -55,7 +55,7 @@ func (s *Server) sweepRoutes() {
 				// its port, then crashed moments later — a race where
 				// waitForReady's success path already cleared any failure.
 				if r.LoadFailure() == nil {
-					r.SetFailure(failureFromLog(r.Name, "process exited after becoming ready"))
+					r.SetFailure(failureFromLog(r.Name, "process exited after becoming ready", r.Cmd))
 				}
 				running = false
 			}

--- a/internal/daemon/oauth_bridge.go
+++ b/internal/daemon/oauth_bridge.go
@@ -1,0 +1,131 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+const oauthCallbackPath = "/auth/google/callback"
+
+func (s *Server) validateOAuthBridgeConfig(routeName string, appPort, callbackPort int) error {
+	if callbackPort < 1 || callbackPort > 65535 {
+		return fmt.Errorf("oauth_callback_port must be between 1 and 65535")
+	}
+	if appPort > 0 && callbackPort == appPort {
+		return fmt.Errorf("oauth_callback_port (%d) must differ from route port (%d)", callbackPort, appPort)
+	}
+	if callbackPort == s.cfg.Daemon.Port || (s.cfg.Daemon.TLS.Enabled && callbackPort == s.cfg.Daemon.TLS.Port) {
+		return fmt.Errorf("oauth_callback_port %d conflicts with vibe daemon listener", callbackPort)
+	}
+	for _, r := range s.table.List() {
+		if r.Name != routeName && r.OAuthCallbackPort == callbackPort {
+			return fmt.Errorf("oauth_callback_port %d is already used by route %q", callbackPort, r.Name)
+		}
+	}
+
+	s.oauthBridgeMu.Lock()
+	_, alreadyListening := s.oauthBridgeListeners[callbackPort]
+	s.oauthBridgeMu.Unlock()
+	if alreadyListening {
+		return nil
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", callbackPort))
+	if err != nil {
+		return fmt.Errorf("oauth_callback_port %d is not available: %w", callbackPort, err)
+	}
+	_ = ln.Close()
+	return nil
+}
+
+func (s *Server) reconcileOAuthBridgeListeners() error {
+	wanted := make(map[int]struct{})
+	for _, r := range s.table.List() {
+		if r.OAuthCallbackPort > 0 {
+			if err := s.validateOAuthBridgeConfig(r.Name, r.Port, r.OAuthCallbackPort); err != nil {
+				return err
+			}
+			wanted[r.OAuthCallbackPort] = struct{}{}
+		}
+	}
+
+	s.oauthBridgeMu.Lock()
+	defer s.oauthBridgeMu.Unlock()
+
+	for port, srv := range s.oauthBridgeServers {
+		if _, ok := wanted[port]; ok {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = srv.Shutdown(ctx)
+		cancel()
+		if ln, ok := s.oauthBridgeListeners[port]; ok {
+			_ = ln.Close()
+		}
+		delete(s.oauthBridgeServers, port)
+		delete(s.oauthBridgeListeners, port)
+	}
+
+	for port := range wanted {
+		if _, ok := s.oauthBridgeServers[port]; ok {
+			continue
+		}
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			return fmt.Errorf("oauth_callback_port %d is not available: %w", port, err)
+		}
+		srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			s.handleOAuthCallbackBridge(w, r, port)
+		})}
+		s.oauthBridgeServers[port] = srv
+		s.oauthBridgeListeners[port] = ln
+		go func(p int, server *http.Server, listener net.Listener) {
+			if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+				fmt.Fprintf(os.Stderr, "warning: oauth callback bridge listener %d stopped: %v\n", p, err)
+			}
+		}(port, srv, ln)
+	}
+
+	return nil
+}
+
+func (s *Server) stopOAuthBridgeListeners() {
+	s.oauthBridgeMu.Lock()
+	defer s.oauthBridgeMu.Unlock()
+	for port, srv := range s.oauthBridgeServers {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = srv.Shutdown(ctx)
+		cancel()
+		if ln, ok := s.oauthBridgeListeners[port]; ok {
+			_ = ln.Close()
+		}
+		delete(s.oauthBridgeServers, port)
+		delete(s.oauthBridgeListeners, port)
+	}
+}
+
+func (s *Server) handleOAuthCallbackBridge(w http.ResponseWriter, r *http.Request, callbackPort int) {
+	if r.URL.Path != oauthCallbackPath {
+		http.NotFound(w, r)
+		return
+	}
+
+	var route *Route
+	for _, rt := range s.table.List() {
+		if rt.OAuthCallbackPort == callbackPort {
+			route = rt
+			break
+		}
+	}
+	if route == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	target := fmt.Sprintf("%s://%s.%s%s", s.vibeScheme(), route.Name, s.cfg.Daemon.TLD, r.URL.RequestURI())
+	http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+}

--- a/internal/daemon/oauth_bridge.go
+++ b/internal/daemon/oauth_bridge.go
@@ -25,18 +25,9 @@ func (s *Server) validateOAuthBridgeConfig(routeName string, appPort, callbackPo
 		}
 	}
 
-	s.oauthBridgeMu.Lock()
-	_, alreadyListening := s.oauthBridgeListeners[callbackPort]
-	s.oauthBridgeMu.Unlock()
-	if alreadyListening {
-		return nil
-	}
-
-	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", callbackPort))
-	if err != nil {
-		return fmt.Errorf("oauth_callback_port %d is not available: %w", callbackPort, err)
-	}
-	_ = ln.Close()
+	// Bindability is enforced by reconcileOAuthBridgeListeners (which holds
+	// the actual listener); a probe-and-close here would race against any
+	// concurrent listener acquiring the port between the probe and reconcile.
 	return nil
 }
 

--- a/internal/daemon/oauth_bridge.go
+++ b/internal/daemon/oauth_bridge.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-const oauthCallbackPath = "/auth/google/callback"
-
 func (s *Server) validateOAuthBridgeConfig(routeName string, appPort, callbackPort int) error {
 	if callbackPort < 1 || callbackPort > 65535 {
 		return fmt.Errorf("oauth_callback_port must be between 1 and 65535")
@@ -109,11 +107,6 @@ func (s *Server) stopOAuthBridgeListeners() {
 }
 
 func (s *Server) handleOAuthCallbackBridge(w http.ResponseWriter, r *http.Request, callbackPort int) {
-	if r.URL.Path != oauthCallbackPath {
-		http.NotFound(w, r)
-		return
-	}
-
 	var route *Route
 	for _, rt := range s.table.List() {
 		if rt.OAuthCallbackPort == callbackPort {

--- a/internal/daemon/oauth_fallback_test.go
+++ b/internal/daemon/oauth_fallback_test.go
@@ -88,6 +88,44 @@ func TestOAuthCallbackBridgeListenerRedirectsToVibeHost(t *testing.T) {
 	}
 }
 
+func TestOAuthCallbackBridgeForwardsArbitraryPath(t *testing.T) {
+	s := testServer()
+	defer s.stopOAuthBridgeListeners()
+
+	appPort := pickFreePort(t)
+	callbackPort := pickFreePort(t)
+
+	body, _ := json.Marshal(map[string]any{
+		"name":                "tasks",
+		"port":                appPort,
+		"oauth_callback_port": callbackPort,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/_api/routes", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("register status = %d; body: %s", w.Code, w.Body.String())
+	}
+
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := client.Get("http://localhost:" + strconv.Itoa(callbackPort) + "/api/auth/callback/google?code=abc&state=xyz")
+	if err != nil {
+		t.Fatalf("GET localhost callback bridge: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d; want 307", resp.StatusCode)
+	}
+	want := "http://tasks.test/api/auth/callback/google?code=abc&state=xyz"
+	if got := resp.Header.Get("Location"); got != want {
+		t.Errorf("Location = %q; want %q", got, want)
+	}
+}
+
 func TestAPIRejectsOAuthCallbackPortMatchingRoutePort(t *testing.T) {
 	s := testServer()
 

--- a/internal/daemon/oauth_fallback_test.go
+++ b/internal/daemon/oauth_fallback_test.go
@@ -1,0 +1,107 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func testPortFromURL(t *testing.T, raw string) int {
+	t.Helper()
+	u, err := http.NewRequest(http.MethodGet, raw, nil)
+	if err != nil {
+		t.Fatalf("parse url %q: %v", raw, err)
+	}
+	port, err := strconv.Atoi(u.URL.Port())
+	if err != nil {
+		t.Fatalf("parse port from %q: %v", raw, err)
+	}
+	return port
+}
+
+func TestRouteRequestNoOAuthFallbackRedirect(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("proxied"))
+	}))
+	defer upstream.Close()
+
+	s := testServer()
+	port := testPortFromURL(t, upstream.URL)
+	s.table.Add(&Route{
+		Name:         "screener",
+		Port:         port,
+		Type:         RouteSticky,
+		RegisteredAt: time.Now(),
+	})
+
+	req := httptest.NewRequest("GET", "/auth/google", nil)
+	req.Host = "screener.test"
+	w := httptest.NewRecorder()
+	s.routeRequest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	if got := w.Body.String(); got != "proxied" {
+		t.Errorf("body = %q; want proxied", got)
+	}
+}
+
+func TestOAuthCallbackBridgeListenerRedirectsToVibeHost(t *testing.T) {
+	s := testServer()
+	defer s.stopOAuthBridgeListeners()
+
+	appPort := pickFreePort(t)
+	callbackPort := pickFreePort(t)
+
+	body, _ := json.Marshal(map[string]any{
+		"name":                "screener",
+		"port":                appPort,
+		"oauth_callback_port": callbackPort,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/_api/routes", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("register status = %d; body: %s", w.Code, w.Body.String())
+	}
+
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := client.Get("http://localhost:" + strconv.Itoa(callbackPort) + "/auth/google/callback?code=abc&state=xyz")
+	if err != nil {
+		t.Fatalf("GET localhost callback bridge: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d; want 307", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); got != "http://screener.test/auth/google/callback?code=abc&state=xyz" {
+		t.Errorf("Location = %q; want redirect to screener.test callback", got)
+	}
+}
+
+func TestAPIRejectsOAuthCallbackPortMatchingRoutePort(t *testing.T) {
+	s := testServer()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":                "screener",
+		"port":                8787,
+		"oauth_callback_port": 8787,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/_api/routes", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.apiHandler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400; body: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/daemon/persistence.go
+++ b/internal/daemon/persistence.go
@@ -22,8 +22,10 @@ type stickyEntry struct {
 	IdleTimeout        int       `json:"idle_timeout,omitempty"`
 	Icon               string    `json:"icon,omitempty"`
 	AutoIcon           string    `json:"auto_icon,omitempty"`
-	Proxy              bool      `json:"proxy,omitempty"`
-	InsecureSkipVerify bool      `json:"insecure_skip_verify,omitempty"`
+	Proxy              bool           `json:"proxy,omitempty"`
+	InsecureSkipVerify bool           `json:"insecure_skip_verify,omitempty"`
+	ReservePorts       map[string]int `json:"reserve_ports,omitempty"`
+	OAuthCallbackPort  int            `json:"oauth_callback_port,omitempty"`
 }
 
 // loadStickyRoutes restores persisted routes (sticky, managed, bookmark)
@@ -65,6 +67,8 @@ func loadStickyRoutes(table *RouteTable, dir string) error {
 			AutoIcon:           entry.AutoIcon,
 			Proxy:              entry.Proxy,
 			InsecureSkipVerify: entry.InsecureSkipVerify,
+			ReservePorts:       entry.ReservePorts,
+			OAuthCallbackPort:  entry.OAuthCallbackPort,
 		}
 		// Managed routes start not running until launched; others are assumed ready.
 		r.Running.Store(rt != RouteManaged)
@@ -92,6 +96,8 @@ func saveStickyRoutes(table *RouteTable, dir string) error {
 				AutoIcon:           r.AutoIcon,
 				Proxy:              r.Proxy,
 				InsecureSkipVerify: r.InsecureSkipVerify,
+				ReservePorts:       r.ReservePorts,
+				OAuthCallbackPort:  r.OAuthCallbackPort,
 			}
 		}
 	}

--- a/internal/daemon/process.go
+++ b/internal/daemon/process.go
@@ -67,8 +67,13 @@ func (pm *ProcessManager) Start(route *Route) (int, error) {
 	cmd := exec.Command(shell, "-lic", route.Cmd)
 	cmd.Dir = route.Dir
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	// Inject PORT env var so frameworks can auto-detect the assigned port.
+	// Inject PORT (primary) plus PORT_<UPPER_NAME> for each reserve_ports entry
+	// so the cmd can reference auxiliary ports by semantic name (e.g.
+	// $PORT_SERVER) instead of hardcoding values that drift from vibe.json.
 	cmd.Env = append(os.Environ(), fmt.Sprintf("PORT=%d", route.Port))
+	for name, p := range route.ReservePorts {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PORT_%s=%d", strings.ToUpper(name), p))
+	}
 
 	logDir := config.Dir()
 	_ = os.MkdirAll(logDir, 0755)

--- a/internal/daemon/route_request_managed_test.go
+++ b/internal/daemon/route_request_managed_test.go
@@ -1,0 +1,79 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManagedStoppedRouteDoesNotProxyForeignListener(t *testing.T) {
+	foreign := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("foreign-app"))
+	}))
+	defer foreign.Close()
+
+	s := testServer()
+	port := testPortFromURL(t, foreign.URL)
+	route := &Route{
+		Name:         "lp",
+		Type:         RouteManaged,
+		Port:         port,
+		Cmd:          "npm run dev",
+		RegisteredAt: time.Now(),
+	}
+	route.Running.Store(false)
+	route.Ready.Store(false)
+	s.table.Add(route)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "lp.test"
+	w := httptest.NewRecorder()
+	s.routeRequest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "foreign-app") {
+		t.Fatalf("unexpected proxy to foreign listener on reused port")
+	}
+	if !strings.Contains(body, "/_api/routes/lp/start") {
+		t.Fatalf("expected managed start page, got: %s", body)
+	}
+}
+
+func TestManagedRunningRouteStillProxies(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	s := testServer()
+	port := testPortFromURL(t, upstream.URL)
+	route := &Route{
+		Name:         "app",
+		Type:         RouteManaged,
+		Port:         port,
+		Cmd:          "npm run dev",
+		RegisteredAt: time.Now(),
+	}
+	route.SetPID(os.Getpid())
+	route.Running.Store(true)
+	route.Ready.Store(true)
+	s.table.Add(route)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "app.test"
+	w := httptest.NewRecorder()
+	s.routeRequest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	if got := w.Body.String(); got != "ok" {
+		t.Fatalf("body = %q; want ok", got)
+	}
+}

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -155,6 +155,23 @@ func (t *RouteTable) Get(name string) (*Route, bool) {
 	return r, ok
 }
 
+// UpdateManagedConfig rewrites the Cmd, OAuthCallbackPort, and ReservePorts
+// fields of a managed route under the table lock so concurrent readers (the
+// monitor goroutine, dashboard renderer, route lookups) never observe a torn
+// write. Returns false if the route is unknown.
+func (t *RouteTable) UpdateManagedConfig(name, cmd string, oauthCallbackPort int, reservePorts map[string]int) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	r, ok := t.routes[name]
+	if !ok {
+		return false
+	}
+	r.Cmd = cmd
+	r.OAuthCallbackPort = oauthCallbackPort
+	r.ReservePorts = reservePorts
+	return true
+}
+
 // UpdatePort rewrites an existing route's Port field under the table lock.
 // Returns false if the route is unknown. Used by the self-healing repair
 // flow when a managed app rebinds itself to a different port.

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -34,6 +34,11 @@ type Route struct {
 	Icon         string     `json:"icon,omitempty"`         // user-chosen emoji or URL for dashboard
 	AutoIcon     string     `json:"auto_icon,omitempty"`    // auto-detected favicon (data URI)
 
+	// Optional OAuth bridge: if set, vibe binds localhost:<OAuthCallbackPort>
+	// and redirects /auth/google/callback to {name}.{tld}. This lets apps keep
+	// localhost redirect URIs while sessions are established on the .vibe host.
+	OAuthCallbackPort int `json:"oauth_callback_port,omitempty"`
+
 	// Bookmark-only: when true, requests to name.vibe are reverse-proxied to
 	// ExternalURL instead of 307-redirected, so the browser keeps the .vibe
 	// host in the URL bar. InsecureSkipVerify disables upstream TLS

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -39,6 +39,18 @@ type Route struct {
 	// localhost redirect URIs while sessions are established on the .vibe host.
 	OAuthCallbackPort int `json:"oauth_callback_port,omitempty"`
 
+	// ReservePorts are named auxiliary ports the command binds beyond Port
+	// (e.g. a backend on 3001 alongside the routed Vite client on Port).
+	// Each name is exposed to the spawned process as PORT_<UPPER_NAME>, so
+	// the cmd can reference $PORT_SERVER instead of hardcoding values that
+	// drift out of sync with this config.
+	//
+	// Vibe doesn't proxy these — they're reserved (findFreePort won't hand
+	// them to other routes) and pre-flight checked on Start so a stale
+	// holder surfaces a recovery hint instead of bleeding traffic into the
+	// wrong app. Names must match [a-zA-Z][a-zA-Z0-9_]*.
+	ReservePorts map[string]int `json:"reserve_ports,omitempty"`
+
 	// Bookmark-only: when true, requests to name.vibe are reverse-proxied to
 	// ExternalURL instead of 307-redirected, so the browser keeps the .vibe
 	// host in the URL bar. InsecureSkipVerify disables upstream TLS

--- a/internal/daemon/setup.md
+++ b/internal/daemon/setup.md
@@ -5,10 +5,11 @@ docs, see the [README](https://github.com/graiz/local.vibe#readme).
 
 ## 1. Add a vibe.json to your project root
 
+**Recommended** — omit `port` and let vibe pick one:
+
 ```json
 {
   "name": "myapp",
-  "port": 3000,
   "cmd": "npm run dev"
 }
 ```
@@ -16,25 +17,87 @@ docs, see the [README](https://github.com/graiz/local.vibe#readme).
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | yes | Subdomain: `name.{{TLD}}` |
-| `port` | no | Port your app listens on (omit or `0` for auto-assign) |
+| `port` | no | **Leave this out.** Only set it when the app can't honor `$PORT` |
 | `cmd` | yes | Shell command to start the app |
 | `icon` | no | Emoji for the dashboard (e.g. `"🚀"`) |
 | `idle_timeout` | no | Auto-stop after N minutes idle (0 = never) |
+| `oauth_callback_port` | no | Fixed localhost port for OAuth callbacks (see below) |
+| `reserve_ports` | no | Named auxiliary ports the cmd binds beyond `port` (see below) |
 
-### Automatic port assignment
+### Automatic port assignment (recommended)
 
-Omit `port` and vibe picks a free port (starting from 3000) and injects it as the
-`PORT` environment variable. Most frameworks respect this automatically:
+Skip `port` and vibe picks a free one (starting from 3000) and injects it as
+the `PORT` environment variable. Most frameworks respect this automatically —
+no two projects will ever collide, and the assigned port persists across
+restarts.
+
+Your app reads `process.env.PORT` (Node), `os.environ["PORT"]` (Python), etc.
+Pin a specific port only when the app hard-codes it or an external system
+(e.g. a webhook) must reach a known number.
+
+### Apps that bind more than one port
+
+Some dev setups run multiple processes that each bind their own port — a
+backend on one port, a frontend dev server on another, maybe a metrics
+endpoint on a third. Vibe routes traffic to a single `port` (the one
+`name.{{TLD}}` resolves to), but the other ports still need to be reserved
+so vibe doesn't auto-assign them to a different app and so collisions
+surface as a clear error instead of silent traffic bleed-through.
+
+Declare the auxiliary ports as a `reserve_ports` map keyed by a semantic
+name. Each entry is exposed to your cmd as `PORT_<UPPER_NAME>`, so the
+command never has to hardcode numeric values:
 
 ```json
 {
   "name": "myapp",
-  "cmd": "npm run dev"
+  "port": 3012,
+  "reserve_ports": { "server": 3001, "metrics": 9090 },
+  "cmd": "concurrently \"cd server && PORT=$PORT_SERVER bun start\" \"cd client && bun dev -- --port $PORT\""
 }
 ```
 
-Your app reads `process.env.PORT` (Node), `os.environ["PORT"]` (Python), etc.
-The assigned port is shown in CLI output and persisted across restarts.
+What vibe does with this:
+
+- **Reserves** every value across the route table — `findFreePort` will not
+  hand `3001` or `9090` to any other route, even after this app stops.
+- **Pre-flights** each port on `vibe start`. If something stale holds one
+  of them, the start page surfaces a recovery hint with the offending PID
+  and a one-click "Kill PID X and retry" button — same UX as a primary-port
+  collision.
+- **Injects** `PORT_SERVER=3001` and `PORT_METRICS=9090` as env vars when
+  spawning the cmd, alongside the usual `PORT=3012` for the routed port.
+
+Naming rules:
+
+- Keys must match `[a-zA-Z][a-zA-Z0-9_]*`. Case-insensitive — `Server` and
+  `server` are the same key; the env var is always uppercase (`PORT_SERVER`).
+- The literal name `port` is rejected (it would collide with the primary
+  `$PORT`).
+- Each port number must be unique across `port`, `oauth_callback_port`,
+  and the rest of `reserve_ports`. Two names mapping to the same number is
+  rejected — give it one canonical `$PORT_<NAME>`.
+
+### OAuth with localhost callbacks
+
+Some OAuth providers (Google, GitHub Apps, etc.) only allow redirect URIs on
+`http://localhost:<port>`. Add `oauth_callback_port` and vibe opens a localhost
+bridge on that port that 307-forwards **any** callback path to your `.{{TLD}}`
+host — so `http://localhost:8787/auth/google/callback?...` and NextAuth's
+`http://localhost:8787/api/auth/callback/google?...` both work unchanged:
+
+```json
+{
+  "name": "myapp",
+  "cmd": "npm run dev",
+  "oauth_callback_port": 8787
+}
+```
+
+The callback port must differ from the app's own port. For bookmark routes
+pointing at an upstream that needs OAuth over `https://name.{{TLD}}`, enable
+the per-route `proxy` option in the dashboard so cookies and redirects stay
+on the `.{{TLD}}` origin.
 
 ## 2. Start it
 

--- a/internal/daemon/startpage.go
+++ b/internal/daemon/startpage.go
@@ -171,15 +171,22 @@ function showRecovery(rec, logTail){
   lastRecovery=rec;
   var box=document.getElementById('recovery');
   var btn=document.getElementById('recovery-btn');
-  btn.style.display='inline-flex';
-  btn.disabled=false;
   document.getElementById('recovery-msg').textContent=rec.message||'Recoverable error';
-  var label='Kill and Retry';
-  if(rec.action==='kill_pid' && rec.pid) label='Kill PID '+rec.pid+' and Retry';
-  else if(rec.action==='kill_port' && rec.port) label='Free Port '+rec.port+' and Retry';
-  else if(rec.action==='restart') label=(rec.pid?'Restart Process (PID '+rec.pid+')':'Restart Process');
-  btn.textContent=label;
   var logEl=document.getElementById('log-tail');
+  // "info" actions are diagnostic only (e.g., missing pip module) — render
+  // the message + log tail with no button, since the fix requires user input.
+  if(rec.action==='info'){
+    btn.style.display='none';
+  }else{
+    btn.style.display='inline-flex';
+    btn.disabled=false;
+    var label='Kill and Retry';
+    if(rec.action==='kill_pid' && rec.pid) label='Kill PID '+rec.pid+' and Retry';
+    else if(rec.action==='kill_port' && rec.port) label='Free Port '+rec.port+' and Retry';
+    else if(rec.action==='restart') label=(rec.pid?'Restart Process (PID '+rec.pid+')':'Restart Process');
+    else if(rec.action==='edit_cmd' && rec.suggested_cmd) label='Use \u0060'+rec.suggested_cmd+'\u0060 and Retry';
+    btn.textContent=label;
+  }
   if(logTail){logEl.textContent=logTail;logEl.style.display='block';}else{logEl.style.display='none';}
   box.style.display='block';
 }
@@ -274,7 +281,8 @@ function cancelLaunch(){
 
 function recoverAndRetry(){
   if(!lastRecovery)return;
-  document.getElementById('recovery-btn').disabled=true;
+  var rbtn=document.getElementById('recovery-btn');
+  rbtn.disabled=true;
   // "restart" means: stop the stuck child, then start fresh. Used when the
   // process is alive but never bound its port — safeKillPID refuses to
   // signal managed-owned PIDs, so a plain kill_pid won't work here.
@@ -284,6 +292,32 @@ function recoverAndRetry(){
     stop.onload=function(){setTimeout(function(){startApp();},300);};
     stop.onerror=function(){startApp();};
     stop.send();
+    return;
+  }
+  // "edit_cmd" rewrites the route's cmd (e.g. python → python3) via PUT,
+  // updates the visible cmd preview, then retries. The cmd field on this
+  // page is server-rendered, so we patch its textContent in-place too.
+  if(lastRecovery.action==='edit_cmd' && lastRecovery.suggested_cmd){
+    var put=new XMLHttpRequest();
+    put.open('PUT','/_api/routes/%[3]s');
+    put.setRequestHeader('Content-Type','application/json');
+    put.onload=function(){
+      if(put.status>=200&&put.status<300){
+        var cmdEl=document.querySelector('.cmd');
+        if(cmdEl)cmdEl.textContent=lastRecovery.suggested_cmd;
+        startApp();
+      }else{
+        rbtn.disabled=false;
+        var em=document.getElementById('msg');
+        em.style.display='block';em.textContent='Failed to update command';em.style.color='var(--red)';
+      }
+    };
+    put.onerror=function(){
+      rbtn.disabled=false;
+      var em=document.getElementById('msg');
+      em.style.display='block';em.textContent='Could not reach daemon';em.style.color='var(--red)';
+    };
+    put.send(JSON.stringify({cmd:lastRecovery.suggested_cmd}));
     return;
   }
   var body={};
@@ -360,7 +394,7 @@ func (s *Server) startPageRecoveryInitJS(route *Route) string {
 		if tail == "" {
 			return ""
 		}
-		rec := scanLogForRecovery(tail)
+		rec := scanLogForRecovery(tail, route.Cmd)
 		if rec == nil {
 			return ""
 		}

--- a/internal/daemon/startpage.go
+++ b/internal/daemon/startpage.go
@@ -92,9 +92,9 @@ h1{font-family:var(--font-display);font-size:1.1rem;font-weight:400;color:var(--
   <div class="url">%[3]s.%[4]s</div>
   <div class="status"><span class="led led-red"></span>Stopped</div>
   <div class="cmd">%[5]s</div>
-  <button class="start-btn" id="btn" onclick="startApp()">Start</button>
-  <div class="page-spinner" id="spinner"></div>
-  <div class="msg" id="msg"></div>
+  <button class="start-btn" id="btn" onclick="handlePrimaryButton()">Cancel</button>
+  <div class="page-spinner" id="spinner" style="display:block"></div>
+  <div class="msg" id="msg" style="display:block;color:var(--text-muted)">Launching process…</div>
   <div class="recovery" id="recovery">
     <div class="recovery-msg" id="recovery-msg"></div>
     <button class="recovery-btn" id="recovery-btn" onclick="recoverAndRetry()"></button>
@@ -103,6 +103,64 @@ h1{font-family:var(--font-display);font-size:1.1rem;font-weight:400;color:var(--
 </div>
 <script>
 var lastRecovery=null;
+var launchCanceled=false;
+var activeXHR=null;
+var launchMode='cancel'; // cancel | retry
+
+function setLaunchMode(mode){
+  launchMode=mode;
+  var btn=document.getElementById('btn');
+  if(mode==='cancel'){
+    btn.disabled=false;
+    btn.textContent='Cancel';
+    return;
+  }
+  btn.disabled=false;
+  btn.textContent='Retry';
+}
+
+function handlePrimaryButton(){
+  if(launchMode==='cancel'){
+    cancelLaunch();
+    return;
+  }
+  startApp();
+}
+
+// fetchFailureAndRender pulls the most recent Failure off /ready and renders
+// it on the page. Retries up to 3 times at 1s intervals to cover the race
+// where the frontend poll timeout fires a beat before waitForReady writes
+// its failure record.
+function fetchFailureAndRender(tries){
+  var msg=document.getElementById('msg');
+  var spinner=document.getElementById('spinner');
+  var fx=new XMLHttpRequest();
+  fx.open('GET','/_api/routes/%[3]s/ready');
+  fx.timeout=2000;
+  fx.onload=function(){
+    var d=null;try{d=JSON.parse(fx.responseText);}catch(e){}
+    if(d&&d.failure){
+      setLaunchMode('retry');spinner.style.display='none';
+      msg.style.whiteSpace='pre-wrap';msg.style.textAlign='left';msg.style.fontSize='.75rem';
+      msg.textContent=d.failure.message||'Server never became ready';
+      msg.style.color='var(--red)';
+      if(d.failure.recovery){showRecovery(d.failure.recovery, d.failure.log||'');}
+      else if(d.failure.log){showFailureLog(d.failure.log);}
+      return;
+    }
+    if(tries<3){setTimeout(function(){fetchFailureAndRender(tries+1);},1000);return;}
+    setLaunchMode('retry');spinner.style.display='none';
+    msg.textContent='Taking too long \u2014 check logs';
+    msg.style.color='var(--yellow)';
+  };
+  fx.onerror=fx.ontimeout=function(){
+    if(tries<3){setTimeout(function(){fetchFailureAndRender(tries+1);},1000);return;}
+    setLaunchMode('retry');spinner.style.display='none';
+    msg.textContent='Taking too long \u2014 check logs';
+    msg.style.color='var(--yellow)';
+  };
+  fx.send();
+}
 
 function hideRecovery(){
   document.getElementById('recovery').style.display='none';
@@ -112,39 +170,56 @@ function hideRecovery(){
 function showRecovery(rec, logTail){
   lastRecovery=rec;
   var box=document.getElementById('recovery');
+  var btn=document.getElementById('recovery-btn');
+  btn.style.display='inline-flex';
+  btn.disabled=false;
   document.getElementById('recovery-msg').textContent=rec.message||'Recoverable error';
   var label='Kill and Retry';
   if(rec.action==='kill_pid' && rec.pid) label='Kill PID '+rec.pid+' and Retry';
   else if(rec.action==='kill_port' && rec.port) label='Free Port '+rec.port+' and Retry';
-  document.getElementById('recovery-btn').textContent=label;
+  else if(rec.action==='restart') label=(rec.pid?'Restart Process (PID '+rec.pid+')':'Restart Process');
+  btn.textContent=label;
   var logEl=document.getElementById('log-tail');
   if(logTail){logEl.textContent=logTail;logEl.style.display='block';}else{logEl.style.display='none';}
   box.style.display='block';
 }
 
+function showFailureLog(logTail){
+  lastRecovery=null;
+  var box=document.getElementById('recovery');
+  var btn=document.getElementById('recovery-btn');
+  var logEl=document.getElementById('log-tail');
+  document.getElementById('recovery-msg').textContent='No automatic recovery available. See log tail:';
+  btn.style.display='none';
+  if(logTail){logEl.textContent=logTail;logEl.style.display='block';}else{logEl.style.display='none';}
+  box.style.display='block';
+}
+
 function startApp(body){
+  launchCanceled=false;
   hideRecovery();
-  var btn=document.getElementById('btn');
   var spinner=document.getElementById('spinner');
   var msg=document.getElementById('msg');
-  btn.disabled=true;
-  btn.textContent='Starting\u2026';
+  setLaunchMode('cancel');
   spinner.style.display='block';
   msg.style.display='block';
   msg.style.color='var(--text-muted)';
+  msg.style.whiteSpace='normal';msg.style.textAlign='center';msg.style.fontSize='.8rem';
   msg.textContent='Launching process\u2026';
 
   var xhr=new XMLHttpRequest();
+  activeXHR=xhr;
   xhr.open('POST','/_api/routes/%[3]s/start');
   xhr.setRequestHeader('Accept','application/json');
   if(body){xhr.setRequestHeader('Content-Type','application/json');}
   xhr.onload=function(){
+    activeXHR=null;
+    if(launchCanceled){return;}
     if(xhr.status===200){
       msg.textContent='Waiting for server\u2026';
       pollUntilReady(0);
     }else{
-      btn.disabled=false;
-      btn.textContent='Retry';
+      setLaunchMode('retry');
       spinner.style.display='none';
       var errMsg='Failed to start';
       var d=null;
@@ -153,11 +228,13 @@ function startApp(body){
       msg.textContent=errMsg;
       msg.style.color='var(--red)';
       if(d&&d.recovery){showRecovery(d.recovery, d.log||'');}
+      else if(d&&d.log){showFailureLog(d.log);}
     }
   };
   xhr.onerror=function(){
-    btn.disabled=false;
-    btn.textContent='Start';
+    activeXHR=null;
+    if(launchCanceled){return;}
+    setLaunchMode('retry');
     spinner.style.display='none';
     msg.textContent='Could not reach daemon';
     msg.style.color='var(--red)';
@@ -165,23 +242,70 @@ function startApp(body){
   xhr.send(body?JSON.stringify(body):null);
 }
 
+function cancelLaunch(){
+  launchCanceled=true;
+  if(activeXHR){
+    try{activeXHR.abort();}catch(e){}
+    activeXHR=null;
+  }
+  var btn=document.getElementById('btn');
+  var spinner=document.getElementById('spinner');
+  var msg=document.getElementById('msg');
+  btn.disabled=true;
+  var stop=new XMLHttpRequest();
+  stop.open('DELETE','/_api/routes/%[3]s/stop');
+  stop.onload=function(){
+    spinner.style.display='none';
+    msg.style.display='block';
+    msg.style.whiteSpace='normal';msg.style.textAlign='center';msg.style.fontSize='.8rem';
+    msg.textContent='Start canceled';
+    msg.style.color='var(--yellow)';
+    setLaunchMode('retry');
+  };
+  stop.onerror=function(){
+    spinner.style.display='none';
+    msg.style.display='block';
+    msg.textContent='Could not cancel cleanly — safe to retry';
+    msg.style.color='var(--yellow)';
+    setLaunchMode('retry');
+  };
+  stop.send();
+}
+
 function recoverAndRetry(){
   if(!lastRecovery)return;
+  document.getElementById('recovery-btn').disabled=true;
+  // "restart" means: stop the stuck child, then start fresh. Used when the
+  // process is alive but never bound its port — safeKillPID refuses to
+  // signal managed-owned PIDs, so a plain kill_pid won't work here.
+  if(lastRecovery.action==='restart'){
+    var stop=new XMLHttpRequest();
+    stop.open('DELETE','/_api/routes/%[3]s/stop');
+    stop.onload=function(){setTimeout(function(){startApp();},300);};
+    stop.onerror=function(){startApp();};
+    stop.send();
+    return;
+  }
   var body={};
   if(lastRecovery.action==='kill_pid'&&lastRecovery.pid)body.kill_pid=lastRecovery.pid;
   else if(lastRecovery.action==='kill_port'&&lastRecovery.port)body.kill_port=lastRecovery.port;
   else return;
-  document.getElementById('recovery-btn').disabled=true;
   startApp(body);
 }
 
+// Poll ~35s — slightly longer than waitForReady's 30s deadline so the
+// backend's Failure record is reliably in place when we ask for it.
 function pollUntilReady(attempts){
-  if(attempts>60){
-    document.getElementById('msg').textContent='Taking too long \u2014 check logs';
-    document.getElementById('msg').style.color='var(--yellow)';
-    document.getElementById('btn').disabled=false;
-    document.getElementById('btn').textContent='Retry';
-    document.getElementById('spinner').style.display='none';
+  if(launchCanceled){return;}
+  if(attempts>70){
+    // Poll stopped making progress. Ask /ready once more: the backend's
+    // waitForReady writes a Failure (log tail + recovery hint or a
+    // "restart" fallback) when its own deadline expires, so we can show
+    // the tail and a one-click recovery button instead of just "check logs".
+    var msg=document.getElementById('msg');
+    var btn=document.getElementById('btn');
+    var spinner=document.getElementById('spinner');
+    fetchFailureAndRender(0);
     return;
   }
   var xhr=new XMLHttpRequest();
@@ -201,10 +325,10 @@ function pollUntilReady(attempts){
         msgEl.style.whiteSpace='pre-wrap';msgEl.style.textAlign='left';msgEl.style.fontSize='.75rem';
         msgEl.textContent=(d.failure&&d.failure.message)?d.failure.message:'Process crashed \u2014 check logs at ~/.vibe/%[3]s.log';
         msgEl.style.color='var(--red)';
-        document.getElementById('btn').disabled=false;
-        document.getElementById('btn').textContent='Retry';
+        setLaunchMode('retry');
         document.getElementById('spinner').style.display='none';
         if(d.failure&&d.failure.recovery){showRecovery(d.failure.recovery, d.failure.log||'');}
+        else if(d.failure&&d.failure.log){showFailureLog(d.failure.log);}
         return;
       }
     }catch(e){}
@@ -215,6 +339,7 @@ function pollUntilReady(attempts){
   xhr.send();
 }
 %[6]s
+startApp();
 </script>
 </body>
 </html>

--- a/internal/daemon/startpage_recovery_test.go
+++ b/internal/daemon/startpage_recovery_test.go
@@ -17,7 +17,7 @@ func TestServeStartPageRecoveryUI(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.serveStartPage(w, httptest.NewRequest("GET", "/", nil), route)
 	body := w.Body.String()
-	for _, token := range []string{`id="recovery"`, `id="recovery-btn"`, `showRecovery`, `recoverAndRetry`, `kill_pid`} {
+	for _, token := range []string{`id="recovery"`, `id="recovery-btn"`, `showRecovery`, `recoverAndRetry`, `kill_pid`, `cancelLaunch`, `startApp();`, `>Cancel<`} {
 		if !strings.Contains(body, token) {
 			t.Errorf("start page missing %q", token)
 		}

--- a/internal/daemon/sync_config.go
+++ b/internal/daemon/sync_config.go
@@ -1,0 +1,105 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+// vibeJSONFields mirrors the subset of vibe.json the CLI's register flow
+// supplies. The daemon re-reads it from a managed route's Dir on every Start
+// so that edits to oauth_callback_port, reserve_ports, or cmd take effect
+// without requiring the user to deregister and re-register the route.
+//
+// Fields not in this struct (icon, idle_timeout) aren't touched here — they're
+// owned by the dashboard CRUD flow today, not vibe.json.
+type vibeJSONFields struct {
+	Name              string         `json:"name"`
+	Port              int            `json:"port"`
+	Cmd               string         `json:"cmd"`
+	OAuthCallbackPort *int           `json:"oauth_callback_port,omitempty"`
+	ReservePorts      map[string]int `json:"reserve_ports,omitempty"`
+}
+
+// syncRouteFromVibeJSON re-reads vibe.json from the route's Dir (if any) and
+// applies oauth_callback_port, reserve_ports, and cmd updates to the in-memory
+// route. Validates collisions and reconciles the OAuth bridge listeners when
+// the callback port changes. Persists routes.json on success.
+//
+// No-ops when Dir is empty, vibe.json is missing, or the file's `name` field
+// disagrees with the route — that mismatch usually means the user is starting
+// the wrong route from this directory and we'd rather not silently retag fields
+// from a stranger's config onto this route.
+//
+// Returns an error only for actively invalid edits the daemon should refuse
+// (collision, malformed reserve_ports). A missing or unreadable file is a
+// silent no-op so a route that lost its source dir still starts from the
+// last-known config.
+func (s *Server) syncRouteFromVibeJSON(route *Route) error {
+	if route.Type != RouteManaged || route.Dir == "" {
+		return nil
+	}
+	data, err := os.ReadFile(filepath.Join(route.Dir, "vibe.json"))
+	if err != nil {
+		return nil
+	}
+	var cfg vibeJSONFields
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		// Malformed config shouldn't block start — the user can keep the
+		// old in-memory copy running while they fix the file.
+		fmt.Fprintf(os.Stderr, "vibe: %s vibe.json is invalid, using last-known config: %v\n", route.Name, err)
+		return nil
+	}
+	if cfg.Name != "" && cfg.Name != route.Name {
+		// Don't cross-pollinate fields between routes. The user is probably
+		// in the wrong directory.
+		return nil
+	}
+
+	// Compute the candidate new state. Validate it before mutating the route
+	// so a bad edit leaves the route bootable from its last-known config.
+	newCmd := cfg.Cmd
+	if newCmd == "" {
+		newCmd = route.Cmd
+	}
+	newOAuth := route.OAuthCallbackPort
+	if cfg.OAuthCallbackPort != nil {
+		newOAuth = *cfg.OAuthCallbackPort
+	}
+	newReserve, err := validateReservePorts(cfg.ReservePorts, route.Port, newOAuth)
+	if err != nil {
+		return err
+	}
+	if newOAuth > 0 {
+		if err := s.validateOAuthBridgeConfig(route.Name, route.Port, newOAuth); err != nil {
+			return err
+		}
+	}
+	if conflictPort, conflictRoute := reservePortConflictsWith(s.table, route.Name, newReserve); conflictPort != 0 {
+		return fmt.Errorf("reserve_ports value %d conflicts with route %q", conflictPort, conflictRoute)
+	}
+
+	changed := false
+	if newCmd != route.Cmd {
+		route.Cmd = newCmd
+		changed = true
+	}
+	if newOAuth != route.OAuthCallbackPort {
+		route.OAuthCallbackPort = newOAuth
+		changed = true
+	}
+	if !reflect.DeepEqual(newReserve, route.ReservePorts) {
+		route.ReservePorts = newReserve
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+
+	if err := s.reconcileOAuthBridgeListeners(); err != nil {
+		return fmt.Errorf("oauth bridge reconcile: %w", err)
+	}
+	return s.saveStickyRoutes()
+}

--- a/internal/daemon/sync_config.go
+++ b/internal/daemon/sync_config.go
@@ -81,20 +81,15 @@ func (s *Server) syncRouteFromVibeJSON(route *Route) error {
 		return fmt.Errorf("reserve_ports value %d conflicts with route %q", conflictPort, conflictRoute)
 	}
 
-	changed := false
-	if newCmd != route.Cmd {
-		route.Cmd = newCmd
-		changed = true
-	}
-	if newOAuth != route.OAuthCallbackPort {
-		route.OAuthCallbackPort = newOAuth
-		changed = true
-	}
-	if !reflect.DeepEqual(newReserve, route.ReservePorts) {
-		route.ReservePorts = newReserve
-		changed = true
-	}
+	changed := newCmd != route.Cmd ||
+		newOAuth != route.OAuthCallbackPort ||
+		!reflect.DeepEqual(newReserve, route.ReservePorts)
 	if !changed {
+		return nil
+	}
+	// Mutate under the table lock so concurrent readers (monitor, dashboard,
+	// routeRequest) never see a torn write of these plain struct fields.
+	if !s.table.UpdateManagedConfig(route.Name, newCmd, newOAuth, newReserve) {
 		return nil
 	}
 

--- a/internal/daemon/theme.go
+++ b/internal/daemon/theme.go
@@ -13,7 +13,7 @@ func themeHead(title string) string {
 }
 
 // themeCSS is the shared base stylesheet — retro-futurist command center design.
-// NOTE: Used inside fmt.Fprintf so literal %% must be %%.
+// NOTE: Used inside fmt.Fprintf so literal % must be %.
 const themeCSS = `
 :root{
   --bg:#111113;
@@ -81,11 +81,11 @@ a:hover{color:var(--amber)}
 
 /* Spinner */
 @keyframes spin{to{transform:rotate(360deg)}}
-.spinner{display:inline-block;width:12px;height:12px;border:1.5px solid #333;border-top-color:#888;border-radius:50%%;animation:spin .6s linear infinite}
+.spinner{display:inline-block;width:12px;height:12px;border:1.5px solid #333;border-top-color:#888;border-radius:50%;animation:spin .6s linear infinite}
 
 /* LED indicators */
-.led{width:9px;height:9px;border-radius:50%%;flex-shrink:0;display:inline-block;position:relative}
-.led::after{content:'';position:absolute;inset:-3px;border-radius:50%%;opacity:.6;filter:blur(3px)}
+.led{width:9px;height:9px;border-radius:50%;flex-shrink:0;display:inline-block;position:relative}
+.led::after{content:'';position:absolute;inset:-3px;border-radius:50%;opacity:.6;filter:blur(3px)}
 .led-green{background:var(--green);box-shadow:0 0 4px var(--green),0 0 8px var(--green-glow)}
 .led-green::after{background:var(--green-glow)}
 .led-red{background:var(--red);box-shadow:0 0 4px var(--red),0 0 8px var(--red-glow)}
@@ -95,65 +95,192 @@ a:hover{color:var(--amber)}
 .led-gray{background:#4a4a52}
 
 /* Modal */
-.modal-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.65);backdrop-filter:blur(4px);z-index:200;align-items:center;justify-content:center}
+.modal-overlay{display:none;position:fixed;inset:0;background:rgba(6,6,10,.55);backdrop-filter:blur(14px) saturate(120%);z-index:200;align-items:center;justify-content:center;padding:24px}
 .modal-overlay.active{display:flex}
 .modal{
-  background:var(--surface);border:1px solid var(--border);
-  border-radius:var(--radius-lg);padding:28px;width:420px;max-width:92vw;
-  box-shadow:0 16px 48px rgba(0,0,0,.5);
-  animation:modal-in .2s ease;
+  position:relative;
+  background:#1c1c22;
+  border:1px solid var(--border);
+  border-radius:14px;width:460px;max-width:100%;max-height:calc(100vh - 48px);
+  overflow:hidden;display:flex;flex-direction:column;
+  box-shadow:0 24px 64px -8px rgba(0,0,0,.65),0 0 0 1px rgba(255,255,255,.02) inset;
+  animation:modal-in .22s cubic-bezier(.2,.8,.2,1);
 }
-@keyframes modal-in{from{opacity:0;transform:translateY(8px) scale(.97)}to{opacity:1;transform:translateY(0) scale(1)}}
+.modal::before{
+  content:'';position:absolute;top:0;left:0;right:0;height:1px;
+  background:linear-gradient(90deg,transparent,rgba(232,148,58,.4) 30%,rgba(232,148,58,.4) 70%,transparent);
+  pointer-events:none;
+}
+@keyframes modal-in{from{opacity:0;transform:translateY(12px) scale(.96)}to{opacity:1;transform:translateY(0) scale(1)}}
+
+.modal-header{
+  padding:22px 28px 20px;flex-shrink:0;
+  display:flex;align-items:center;gap:18px;
+  border-bottom:1px solid var(--border-subtle);
+}
+.modal-header-text{flex:1;min-width:0;display:flex;flex-direction:column;justify-content:center;gap:2px}
+.modal-eyebrow{
+  display:flex;align-items:center;gap:7px;
+  font-family:var(--font-display);font-size:.66rem;
+  letter-spacing:.16em;text-transform:uppercase;color:var(--amber);
+}
+.modal-eyebrow::before{
+  content:'';width:5px;height:5px;border-radius:50%;
+  background:var(--amber);box-shadow:0 0 6px var(--amber-glow);
+}
 .modal h3{
-  font-family:var(--font-display);font-size:1rem;
-  letter-spacing:.08em;text-transform:uppercase;
-  color:var(--amber);margin-bottom:20px;
+  font-family:var(--font-display);font-size:1.3rem;
+  letter-spacing:.02em;color:var(--text);
+  text-transform:none;line-height:1.1;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
 }
-.modal label{display:block;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:var(--text-muted);margin-bottom:6px;margin-top:16px}
-.modal label:first-of-type{margin-top:0}
+.modal-sub{font-size:.74rem;color:var(--text-muted);letter-spacing:.02em;line-height:1.4}
+
+/* Header icon — clickable, opens picker popover */
+.icon-trigger{
+  width:56px;height:56px;border-radius:12px;flex-shrink:0;
+  background:linear-gradient(180deg,#22222a,#1a1a20);
+  border:1px solid var(--border);cursor:pointer;
+  display:flex;align-items:center;justify-content:center;
+  font-size:30px;line-height:1;position:relative;
+  background-size:cover;background-position:center;
+  transition:border-color .15s,box-shadow .15s,transform .12s;
+}
+.icon-trigger:hover{border-color:var(--amber);box-shadow:0 0 0 3px rgba(232,148,58,.1)}
+.icon-trigger:active{transform:scale(.96)}
+
+/* Icon popover — anchored under the header icon */
+.icon-popover{
+  position:absolute;top:84px;left:28px;z-index:10;
+  width:320px;padding:14px;
+  background:#1c1c22;border:1px solid var(--border);
+  border-radius:12px;
+  box-shadow:0 12px 32px rgba(0,0,0,.55),0 0 0 1px rgba(255,255,255,.02) inset;
+  display:none;
+  animation:popover-in .15s ease;
+}
+.icon-popover.active{display:block}
+@keyframes popover-in{from{opacity:0;transform:translateY(-4px) scale(.98)}to{opacity:1;transform:translateY(0) scale(1)}}
+.icon-popover .icon-popover-row{display:flex;gap:8px;margin-bottom:10px}
+.icon-popover input{
+  flex:1;width:auto!important;background:rgba(0,0,0,.35);border:1px solid var(--border);
+  border-radius:8px;padding:8px 10px;color:var(--text);
+  font-family:var(--font-body);font-size:.9rem;outline:none;
+}
+.icon-popover input:focus{border-color:var(--amber)}
+.icon-popover .btn-sm{font-size:.7rem;padding:0 12px}
+
+.modal-body{padding:22px 28px;overflow-y:auto;flex:1;min-height:0}
+.modal-body::-webkit-scrollbar{width:6px}
+.modal-body::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
+
+.field{margin-bottom:18px}
+.field:last-child{margin-bottom:0}
+.field-row{display:flex;gap:12px;margin-bottom:18px}
+.field-row .field{flex:1;margin-bottom:0;min-width:0}
+.field-row .field-port{flex:0 0 120px}
+.modal label{display:block;font-size:.66rem;font-weight:600;text-transform:uppercase;letter-spacing:.14em;color:var(--text-muted);margin-bottom:8px}
 .modal input,.modal select{
-  width:100%%;background:var(--bg);border:1px solid var(--border);
-  border-radius:var(--radius);padding:10px 12px;color:var(--text);
-  font-family:var(--font-body);font-size:.88rem;outline:none;
-  transition:border-color .15s;
+  display:block;box-sizing:border-box;
+  width:100%;min-width:0;
+  background:rgba(0,0,0,.35);border:1px solid var(--border);
+  border-radius:8px;padding:11px 13px;color:var(--text);
+  font-family:var(--font-body);font-size:.9rem;outline:none;
+  transition:border-color .15s,background .15s,box-shadow .15s;
 }
-.modal input:focus,.modal select:focus{border-color:var(--amber)}
-.modal input::placeholder{color:var(--text-muted)}
-.modal-actions{display:flex;gap:10px;margin-top:22px;justify-content:flex-end}
-.modal .hint{color:var(--text-muted);font-size:.8rem;margin-top:8px;line-height:1.5}
-.modal .hint code{background:var(--elevated);padding:1px 5px;border-radius:3px;font-family:var(--font-body);color:var(--amber);font-size:.78rem}
-/* Checkbox row — inline label + checkbox, no uppercase tiny tracking */
+.modal input:hover{border-color:var(--text-muted)}
+.modal input:focus,.modal select:focus{border-color:var(--amber);background:rgba(0,0,0,.5);box-shadow:0 0 0 3px rgba(232,148,58,.12)}
+.modal input::placeholder{color:#4a4a52}
+
+.modal .hint{color:var(--text-muted);font-size:.76rem;margin-top:6px;line-height:1.55}
+.modal .hint code{background:rgba(232,148,58,.08);padding:1px 6px;border-radius:4px;font-family:var(--font-body);color:var(--amber);font-size:.74rem;border:1px solid rgba(232,148,58,.15)}
+
+/* Options card — groups checkbox-style toggles with subtle container */
+.options-card{
+  background:rgba(0,0,0,.22);border:1px solid var(--border-subtle);
+  border-radius:10px;padding:4px 14px;margin-bottom:18px;
+}
+.options-card .opt{padding:12px 0;border-bottom:1px solid var(--border-subtle)}
+.options-card .opt:last-child{border-bottom:none}
 .modal label.checkbox-row{
-  display:flex;align-items:center;gap:8px;
-  font-size:.88rem;font-weight:400;text-transform:none;letter-spacing:0;
+  display:flex;align-items:center;gap:10px;
+  font-size:.88rem;font-weight:500;text-transform:none;letter-spacing:0;
   color:var(--text);margin:0;cursor:pointer;
 }
 .modal label.checkbox-row input[type=checkbox]{
-  width:auto;margin:0;accent-color:var(--amber);
-  width:16px;height:16px;flex:none;
+  width:16px;height:16px;margin:0;accent-color:var(--amber);flex:none;cursor:pointer;
 }
+.options-card .hint{margin-left:26px;margin-top:4px;font-size:.74rem}
 
-/* Type toggle */
-.type-toggle{display:flex;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;margin-bottom:18px}
+/* Type toggle — refined segmented control with amber underline */
+.type-toggle{
+  display:flex;background:rgba(0,0,0,.3);border:1px solid var(--border);
+  border-radius:8px;padding:3px;margin-bottom:20px;position:relative;
+}
 .type-toggle button{
-  flex:1;padding:9px;background:none;border:none;
-  font-family:var(--font-body);font-size:.78rem;font-weight:600;
-  text-transform:uppercase;letter-spacing:.05em;
-  color:var(--text-muted);cursor:pointer;transition:all .15s;
+  flex:1;padding:8px 12px;background:none;border:none;border-radius:6px;
+  font-family:var(--font-body);font-size:.74rem;font-weight:600;
+  text-transform:uppercase;letter-spacing:.1em;
+  color:var(--text-muted);cursor:pointer;transition:all .18s;
+  position:relative;
 }
-.type-toggle button.active{background:var(--elevated);color:var(--amber)}
+.type-toggle button:hover:not(.active){color:var(--text-secondary)}
+.type-toggle button.active{
+  background:linear-gradient(180deg,rgba(232,148,58,.14),rgba(232,148,58,.06));
+  color:var(--amber);
+  box-shadow:0 1px 0 rgba(255,255,255,.04) inset,0 0 0 1px rgba(232,148,58,.25);
+}
 
-/* Icon input */
-.icon-select-row{display:flex;align-items:center;gap:10px;margin-bottom:8px}
-.icon-preview-lg{width:48px;height:48px;font-size:26px}
-.icon-custom-input{width:120px!important;flex:none!important;text-align:center;font-size:1.1rem!important}
-.btn-sm{font-size:.78rem;padding:4px 12px}
+/* Icon picker — large preview tile + inline custom input */
+.icon-select-row{display:flex;align-items:stretch;gap:10px;margin-bottom:12px}
+.icon-preview-lg{
+  width:54px;height:54px;border-radius:12px;font-size:28px;
+  background:linear-gradient(180deg,#22222a,#1a1a20);
+  border:1px solid var(--border);flex-shrink:0;
+  display:flex;align-items:center;justify-content:center;
+  background-size:cover;background-position:center;
+  box-shadow:0 1px 0 rgba(255,255,255,.03) inset;
+}
 .icon-preview{
-  width:44px;height:44px;border-radius:12px;
+  width:44px;height:44px;border-radius:10px;
   background:var(--elevated);border:1px solid var(--border);
   display:flex;align-items:center;justify-content:center;
   font-size:22px;flex-shrink:0;background-size:cover;background-position:center;
 }
+.icon-custom-input{flex:1!important;width:auto!important;text-align:left;font-size:.9rem!important}
+.btn-sm{font-size:.7rem;padding:0 12px;height:auto;align-self:stretch}
+
+.icon-picker{
+  display:grid;grid-template-columns:repeat(8,1fr);gap:6px;
+  padding:10px;background:rgba(0,0,0,.22);
+  border:1px solid var(--border-subtle);border-radius:10px;
+}
+.icon-pick{
+  aspect-ratio:1;width:auto;height:auto;
+  border-radius:8px;border:1px solid transparent;
+  background:var(--elevated);
+  display:flex;align-items:center;justify-content:center;
+  font-size:18px;cursor:pointer;transition:all .12s;
+}
+.icon-pick:hover{background:var(--hover);transform:translateY(-1px)}
+.icon-pick.selected{
+  border-color:var(--amber);background:rgba(232,148,58,.12);
+  box-shadow:0 0 0 1px var(--amber),0 0 12px var(--amber-glow);
+}
+
+/* Action bar — hairline top border, Delete left as ghost */
+.modal-actions{
+  display:flex;gap:10px;align-items:center;
+  padding:16px 28px;flex-shrink:0;
+  border-top:1px solid var(--border-subtle);
+  background:rgba(0,0,0,.18);
+}
+.modal-actions .btn-add{padding:8px 20px}
+.modal-actions .btn-danger{
+  background:transparent;border-color:transparent;color:var(--text-muted);
+  padding:6px 10px;
+}
+.modal-actions .btn-danger:hover{color:var(--red);background:rgba(229,69,69,.08);border-color:rgba(229,69,69,.2)}
 
 /* Btn icon (edit pencil) */
 .btn-icon{
@@ -166,7 +293,7 @@ a:hover{color:var(--amber)}
 
 /* Toast notifications */
 .toast{
-  position:fixed;bottom:24px;left:50%%;transform:translateX(-50%) translateY(20px);
+  position:fixed;bottom:24px;left:50%;transform:translateX(-50%) translateY(20px);
   background:var(--surface);border:1px solid var(--border);color:var(--text);
   padding:12px 20px;border-radius:var(--radius);font-size:.88rem;
   box-shadow:0 8px 24px rgba(0,0,0,.4);opacity:0;transition:opacity .3s,transform .3s;


### PR DESCRIPTION
## Summary
- **OAuth localhost bridge** (`oauth_bridge.go`): per-route `oauth_callback_port` opens a localhost listener that 307-forwards any callback path to `https://name.vibe/...`, so OAuth providers requiring a `localhost:N` redirect URI work without leaving the .vibe origin.
- **`reserve_ports`** in `vibe.json`: declare auxiliary ports the cmd binds (e.g. backend on one port, frontend on another). Reserved across the route table, pre-flighted with the same kill-and-retry UX as the primary port, and injected as `\$PORT_<UPPER_NAME>` env vars.
- **`vibe.json` hot-resync** (`sync_config.go`): re-reads `vibe.json` on every `Start` so edits to `cmd`, `oauth_callback_port`, or `reserve_ports` take effect without deregister/re-register.
- **`vibe restart`** command — stop + start in one step.
- **Reliability fixes**: route-vanish on rename, data race in vibe.json sync, redesigned route modal, cmd-aware recovery hints (orphan PID / EADDRINUSE) on the start page.
- **Browser-form vs JSON detection**: `/_api/routes/*` handlers now 303-redirect only on `Content-Type: application/x-www-form-urlencoded`, fixing a CLI crash where an empty Accept header triggered a redirect-loop over the Unix socket.
- **Bookmark proxy hardening**: forces upstream Host, rewrites same-origin Location headers, strips `Domain=` from Set-Cookie, suppresses X-Forwarded-For; per-route `insecure_skip_verify`.
- Docs (CLAUDE.md, README.md, setup.md) updated for all of the above.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build\` succeeds
- [ ] Confirm OAuth bridge: register a managed route with \`oauth_callback_port\`, hit \`http://localhost:N/cb?code=x\`, verify 307 to \`https://name.vibe/cb?code=x\`
- [ ] Confirm \`reserve_ports\`: collision pre-flight surfaces orphan PID + retry button
- [ ] Confirm \`vibe restart\` picks up \`vibe.json\` edits without re-register
- [ ] Bookmark proxy still works against Home Assistant / Tailscale upstreams

🤖 Generated with [Claude Code](https://claude.com/claude-code)