### PR TITLE
Extract dashboard HTML into html/template files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ vibe
 .idea/
 *.swp
 *~
+.claude/
 
 # Go
 vendor/

--- a/internal/daemon/dashboard.go
+++ b/internal/daemon/dashboard.go
@@ -2,18 +2,71 @@ package daemon
 
 import (
 	"fmt"
-	"html"
+	"html/template"
 	"net/http"
 	"strings"
 	"time"
 )
 
-// serveDashboard renders the main dashboard HTML page at local.vibe.
+// vibeScheme returns "https" when TLS is enabled, "http" otherwise. Used
+// throughout the dashboard so links to .vibe routes match how the daemon
+// is currently listening.
 func (s *Server) vibeScheme() string {
 	if s.cfg.Daemon.TLS.Enabled {
 		return "https"
 	}
 	return "http"
+}
+
+// dashboardData is the view model rendered into templates/dashboard.html.tmpl.
+// All user-supplied strings (route names, external URLs, icons) are auto-
+// escaped by html/template's contextual escaper; we no longer hand-call
+// html.EscapeString on the way out.
+type dashboardData struct {
+	Head           template.HTML
+	CSS            template.CSS
+	Scheme         string
+	TLD            string
+	Port           int
+	Uptime         string
+	UnknownName    string
+	UnknownVisible bool
+	ListBtnClass   string
+	GridBtnClass   string
+	ListDisplay    string
+	GridDisplay    string
+	RouteCount     int // includes the synthetic "local" daemon row
+	Routes         []dashboardRoute
+}
+
+// dashboardRoute is a single row in the dashboard, derived from a *Route.
+// Resolving the icon and "stopped" flag once here keeps the template free
+// of business logic (e.g. the icon-pool fallback hash).
+type dashboardRoute struct {
+	Name        string
+	VibeURL     string
+	URLDisplay  string
+	Type        RouteType
+	Port        int
+	Age         string
+	IsStopped   bool
+	IsRunning   bool
+	Icon        string
+	UserIcon    string
+	AutoIcon    string
+	ExternalURL string
+	Idle        int
+	Proxy       bool
+	Insecure    bool
+}
+
+// iconPool — visually distinct emoji set. A new route with no user-chosen
+// icon and no auto-detected favicon gets a deterministic pick from this
+// pool keyed off its name, so the dashboard isn't a wall of identical
+// placeholders.
+var iconPool = []string{
+	"🚀", "🤖", "📦", "⚡", "🔮", "🎯", "🛠️", "💎",
+	"🧪", "🌐", "📡", "🎨", "🔒", "🗂️", "📊", "🧩",
 }
 
 func (s *Server) serveDashboard(w http.ResponseWriter, r *http.Request) {
@@ -37,799 +90,78 @@ func (s *Server) serveDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-
 	viewMode := s.cfg.Dashboard.View
 	if viewMode == "" {
 		viewMode = "list"
 	}
 	listBtnClass, gridBtnClass := "active", ""
+	listDisplay, gridDisplay := "block", "none"
 	if viewMode == "grid" {
 		listBtnClass, gridBtnClass = "", "active"
+		listDisplay, gridDisplay = "none", "block"
 	}
 
-	var b strings.Builder
-	fmt.Fprintf(&b, `<!DOCTYPE html>
-<html lang="en">
-<head>
-%s
-<style>%s
-
-/* Nav bar */
-.navbar{
-  display:flex;align-items:center;justify-content:space-between;
-  padding:0 24px;height:52px;background:var(--surface);
-  border-bottom:1px solid var(--border);position:sticky;top:0;z-index:100;
-}
-.navbar-left{display:flex;align-items:center;gap:16px}
-.brand{font-family:var(--font-display);font-size:1.15rem;color:var(--amber);letter-spacing:.5px;text-decoration:none}
-.status-pill{display:flex;align-items:center;gap:8px;font-size:.78rem;color:var(--text-secondary);letter-spacing:.04em;text-transform:uppercase}
-
-/* Main content */
-.main{max-width:960px;margin:0 auto;padding:28px 24px 60px}
-
-/* Toolbar */
-.toolbar{display:flex;align-items:center;justify-content:space-between;margin-bottom:20px}
-.toolbar-left{display:flex;align-items:baseline;gap:10px}
-.toolbar-title{font-family:var(--font-display);font-size:1.1rem;color:var(--text);letter-spacing:.08em;text-transform:uppercase}
-.toolbar-count{font-size:.78rem;color:var(--text-muted);letter-spacing:.04em}
-.view-toggle{display:flex;background:var(--elevated);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
-.view-toggle button{
-  font-family:var(--font-body);background:none;border:none;
-  color:var(--text-muted);padding:6px 12px;cursor:pointer;
-  display:flex;align-items:center;justify-content:center;transition:background .15s,color .15s;
-}
-.view-toggle button:first-child{border-right:1px solid var(--border)}
-.view-toggle button.active{background:var(--hover);color:var(--amber)}
-.view-toggle button:hover:not(.active){color:var(--text-secondary)}
-.view-toggle svg{width:16px;height:16px}
-
-/* Warning banner */
-.warn{
-  display:flex;align-items:center;gap:8px;
-  padding:12px 16px;margin-bottom:20px;
-  font-size:.82rem;color:var(--yellow);
-  background:rgba(212,168,42,.06);
-  border:1px solid rgba(212,168,42,.2);border-radius:var(--radius);
-}
-
-/* Route table (list view) */
-.list-view{width:100%%}
-.route-table{width:100%%;border-collapse:collapse}
-.route-table thead th{
-  font-size:.7rem;text-transform:uppercase;letter-spacing:.1em;
-  color:var(--text-muted);font-weight:500;text-align:left;
-  padding:0 12px 10px;border-bottom:1px solid var(--border);
-}
-.route-table tbody tr{border-bottom:1px solid var(--border-subtle);transition:background .1s}
-.route-table tbody tr:hover{background:var(--elevated)}
-.route-table td{padding:11px 12px;vertical-align:middle}
-.route-name-cell{display:flex;align-items:center;gap:10px}
-.route-icon{
-  width:28px;height:28px;border-radius:7px;
-  display:flex;align-items:center;justify-content:center;
-  font-size:15px;line-height:1;flex-shrink:0;
-  background:var(--elevated);border:1px solid var(--border-subtle);
-}
-.route-icon-stopped{opacity:.35}
-.route-name-link{color:var(--text);text-decoration:none;font-weight:600;font-size:.92rem;transition:color .15s}
-.route-name-link:hover{color:var(--amber)}
-.route-url{color:var(--text-muted);font-size:.75rem;margin-left:4px}
-.td-type{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;font-weight:500;color:var(--text-muted)}
-.td-port{font-variant-numeric:tabular-nums;font-size:.85rem}
-.td-port a{color:var(--text-secondary);text-decoration:none;transition:color .15s}
-.td-port a:hover{color:var(--amber)}
-.td-age{color:var(--text-muted);font-size:.8rem}
-.td-actions{display:flex;align-items:center;gap:6px;justify-content:flex-end}
-.td-stopped{opacity:.45}
-.hide-mobile{}
-
-/* Grid view */
-.grid-view{display:none}
-.grid-container{
-  display:grid;
-  grid-template-columns:repeat(auto-fill,minmax(150px,1fr));
-  gap:16px;
-}
-.grid-tile{
-  background:var(--surface);border:1px solid var(--border-subtle);
-  border-radius:var(--radius-lg);padding:20px 12px 16px;
-  display:flex;flex-direction:column;align-items:center;text-align:center;
-  cursor:pointer;transition:background .15s,border-color .15s,box-shadow .2s;
-  position:relative;text-decoration:none;color:var(--text);
-}
-.grid-tile:hover{background:var(--elevated);border-color:var(--border);box-shadow:0 2px 16px rgba(0,0,0,.3)}
-.grid-tile:hover .tile-hover-action{opacity:1}
-.tile-icon{
-  width:64px;height:64px;border-radius:16px;
-  display:flex;align-items:center;justify-content:center;
-  font-size:30px;margin-bottom:10px;
-  background:var(--elevated);border:1px solid var(--border);
-  flex-shrink:0;
-}
-.tile-stopped .tile-icon{opacity:.35}
-.tile-name{font-weight:600;font-size:.88rem;color:var(--text);margin-bottom:3px;letter-spacing:.02em}
-.tile-url{font-size:.7rem;color:var(--text-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%%}
-.tile-hover-action{position:absolute;top:8px;right:8px;opacity:0;transition:opacity .15s}
-.tile-hover-action .btn{font-size:.65rem;padding:3px 8px}
-
-/* Empty state */
-.empty{text-align:center;padding:48px 0;color:var(--text-muted);font-size:.88rem}
-
-/* Get Started section */
-.get-started{
-  margin-top:36px;background:var(--surface);
-  border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;
-}
-.get-started h2{
-  font-family:var(--font-display);font-size:.95rem;
-  letter-spacing:.1em;text-transform:uppercase;color:var(--amber);margin-bottom:6px;
-}
-.get-started p{font-size:.82rem;color:var(--text-secondary);margin-bottom:14px;line-height:1.5}
-.setup-box{position:relative}
-.setup-textarea{
-  width:100%%;font-family:var(--font-body);font-size:.8rem;
-  background:var(--bg);color:var(--text-secondary);
-  border:1px solid var(--border);border-radius:var(--radius);
-  padding:14px;resize:none;line-height:1.6;
-}
-.btn-copy{
-  position:absolute;top:10px;right:10px;
-  font-family:var(--font-body);font-size:.7rem;font-weight:600;
-  text-transform:uppercase;letter-spacing:.06em;
-  background:var(--elevated);color:var(--text-secondary);
-  border:1px solid var(--border);padding:5px 12px;
-  border-radius:var(--radius);cursor:pointer;transition:all .15s;
-}
-.btn-copy:hover{color:var(--text);border-color:var(--text-muted)}
-
-/* Icon picker */
-.icon-picker{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
-.icon-pick{
-  width:36px;height:36px;border-radius:8px;border:1px solid var(--border);
-  background:var(--bg);display:flex;align-items:center;justify-content:center;
-  font-size:18px;cursor:pointer;transition:all .12s;
-}
-.icon-pick:hover{border-color:var(--amber);background:var(--elevated)}
-.icon-pick.selected{border-color:var(--amber);background:var(--elevated);box-shadow:0 0 8px var(--amber-glow)}
-
-/* Footer */
-.footer{
-  max-width:960px;margin:0 auto;padding:0 24px 32px;
-  display:flex;align-items:center;justify-content:center;
-  gap:20px;font-size:.72rem;color:var(--text-muted);
-}
-.footer a{color:var(--text-muted);text-decoration:none;transition:color .15s}
-.footer a:hover{color:var(--amber)}
-.footer-sep{opacity:.3}
-
-@media(max-width:700px){
-  .navbar{padding:0 16px}
-  .main{padding:20px 16px 48px}
-  .grid-container{grid-template-columns:repeat(auto-fill,minmax(130px,1fr));gap:12px}
-  .hide-mobile{display:none}
-}
-@media(max-width:480px){
-  .grid-container{grid-template-columns:repeat(2,1fr)}
-}
-</style>
-</head>
-<body>
-`, themeHead("local.vibe"), themeCSS)
-
-	// Nav bar
 	uptime := time.Since(s.startedAt).Round(time.Second)
-	fmt.Fprintf(&b, `<nav class="navbar">
-  <div class="navbar-left">
-    <a href="%s://local.%s/" class="brand">local.vibe</a>
-    <div class="status-pill"><span class="led led-green"></span>Running &middot; %s</div>
-  </div>
-  <button class="btn-add" onclick="openAddModal()">+ Add Route</button>
-</nav>
-<main class="main">
-`, scheme, tld, fmtDuration(uptime))
 
-	// Warning banner
-	if unknownName != "" {
-		fmt.Fprintf(&b, `<div class="warn"><span class="led led-yellow"></span>No route for <strong style="color:var(--text);margin:0 4px">%s.%s</strong> — register it below.</div>`,
-			html.EscapeString(unknownName), tld)
+	data := dashboardData{
+		Head:           template.HTML(themeHead("local.vibe")),
+		CSS:            template.CSS(themeCSS),
+		Scheme:         scheme,
+		TLD:            tld,
+		Port:           port,
+		Uptime:         fmtDuration(uptime),
+		UnknownName:    unknownName,
+		UnknownVisible: unknownName != "",
+		ListBtnClass:   listBtnClass,
+		GridBtnClass:   gridBtnClass,
+		ListDisplay:    listDisplay,
+		GridDisplay:    gridDisplay,
+		RouteCount:     len(routes) + 1,
+		Routes:         make([]dashboardRoute, 0, len(routes)),
 	}
 
-	// Toolbar with view toggle
-	fmt.Fprintf(&b, `<div class="toolbar">
-  <div class="toolbar-left">
-    <span class="toolbar-title">Routes</span>
-    <span class="toolbar-count">%d active</span>
-  </div>
-  <div class="view-toggle">
-    <button id="btn-list" class="%s" onclick="setView('list',true)" title="List view">
-      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="1" y1="3" x2="15" y2="3"/><line x1="1" y1="8" x2="15" y2="8"/><line x1="1" y1="13" x2="15" y2="13"/></svg>
-    </button>
-    <button id="btn-grid" class="%s" onclick="setView('grid',true)" title="Grid view">
-      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="5.5" height="5.5" rx="1"/><rect x="9.5" y="1" width="5.5" height="5.5" rx="1"/><rect x="1" y="9.5" width="5.5" height="5.5" rx="1"/><rect x="9.5" y="9.5" width="5.5" height="5.5" rx="1"/></svg>
-    </button>
-  </div>
-</div>
-`, len(routes)+1, listBtnClass, gridBtnClass)
+	for _, rt := range routes {
+		isStopped := rt.Type == RouteManaged && !rt.Running.Load()
 
-	// Pool of visually distinct icons assigned by name hash so each route
-	// gets a consistent, unique-looking icon out of the box.
-	iconPool := []string{
-		"🚀", "🤖", "📦", "⚡", "🔮", "🎯", "🛠️", "💎",
-		"🧪", "🌐", "📡", "🎨", "🔒", "🗂️", "📊", "🧩",
+		urlDisplay := fmt.Sprintf("%s.%s", rt.Name, tld)
+		if rt.Type == RouteBookmark {
+			urlDisplay = rt.ExternalURL
+		}
+
+		// Icon priority: user-chosen > auto-detected favicon > deterministic pool pick.
+		icon := iconPool[nameHash(rt.Name)%len(iconPool)]
+		if rt.AutoIcon != "" {
+			icon = rt.AutoIcon
+		}
+		if rt.Icon != "" {
+			icon = rt.Icon
+		}
+
+		data.Routes = append(data.Routes, dashboardRoute{
+			Name:        rt.Name,
+			VibeURL:     fmt.Sprintf("%s://%s.%s", scheme, rt.Name, tld),
+			URLDisplay:  urlDisplay,
+			Type:        rt.Type,
+			Port:        rt.Port,
+			Age:         fmtDuration(time.Since(rt.RegisteredAt).Round(time.Second)),
+			IsStopped:   isStopped,
+			IsRunning:   rt.Running.Load(),
+			Icon:        icon,
+			UserIcon:    rt.Icon,
+			AutoIcon:    rt.AutoIcon,
+			ExternalURL: rt.ExternalURL,
+			Idle:        rt.IdleTimeout,
+			Proxy:       rt.Proxy,
+			Insecure:    rt.InsecureSkipVerify,
+		})
 	}
 
-	// ── LIST VIEW ──
-	listDisplay := "block"
-	if viewMode == "grid" {
-		listDisplay = "none"
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmplDashboard.Execute(w, data); err != nil {
+		// Headers are already written, so the response is half-rendered
+		// at best. Logging is the only remaining recourse.
+		fmt.Fprintf(w, "\n<!-- template error: %v -->\n", err)
 	}
-	fmt.Fprintf(&b, `<div class="list-view" id="list-view" style="display:%s">
-<table class="route-table">`, listDisplay)
-	b.WriteString(`
-<thead><tr>
-  <th style="width:38%%">Name</th>
-  <th>Type</th>
-  <th>Port</th>
-  <th class="hide-mobile">Age</th>
-  <th style="text-align:right">Actions</th>
-</tr></thead>
-<tbody>`)
-
-	// Self row
-	fmt.Fprintf(&b, `<tr>
-  <td><div class="route-name-cell"><span class="route-icon">&#127968;</span><div><a href="%[4]s://local.%[1]s/" class="route-name-link">local</a><span class="route-url">local.%[1]s</span></div></div></td>
-  <td class="td-type">daemon</td>
-  <td class="td-port"><a href="http://localhost:%[2]d" target="_blank">%[2]d</a></td>
-  <td class="td-age hide-mobile">%[3]s</td>
-  <td></td>
-</tr>`, tld, port, fmtDuration(uptime), scheme)
-
-	// Route rows
-	for _, r := range routes {
-		safeName := html.EscapeString(r.Name)
-		vibeURL := fmt.Sprintf("%s://%s.%s", scheme, safeName, tld)
-
-		isStopped := r.Type == RouteManaged && !r.Running.Load()
-
-		// Secondary URL display
-		urlDisplay := fmt.Sprintf("%s.%s", safeName, tld)
-		if r.Type == RouteBookmark {
-			urlDisplay = html.EscapeString(r.ExternalURL)
-		}
-
-		// Type label (plain text, no color)
-		typeLabel := string(r.Type)
-
-		// Port — link to localhost:port, or dash for bookmarks
-		portCell := fmt.Sprintf(`<a href="http://localhost:%d" target="_blank">%d</a>`, r.Port, r.Port)
-		if r.Type == RouteBookmark {
-			portCell = "—"
-		}
-
-		// Age
-		since := time.Since(r.RegisteredAt).Round(time.Second)
-
-		// Action buttons
-		actionHTML := ""
-		editSVG := `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z"/></svg>`
-		if r.Type == RouteManaged && r.Running.Load() {
-			actionHTML = fmt.Sprintf(`<button class="btn" onclick="routeAction(this,'%s','stop')">Stop</button>`, safeName)
-		} else if r.Type == RouteManaged {
-			actionHTML = fmt.Sprintf(`<button class="btn btn-primary" onclick="routeAction(this,'%s','start')">Start</button>`, safeName)
-		}
-
-		// Edit button — pass user icon and auto icon separately so "Clear" reverts to auto.
-		editBtn := ""
-		safeIcon := html.EscapeString(r.Icon)
-		safeAutoIcon := html.EscapeString(r.AutoIcon)
-		if r.Type == RouteManaged {
-			editBtn = fmt.Sprintf(`<button class="btn-icon" onclick="openManagedModal('%s',%d,'%s','%s')" title="Settings">%s</button>`, safeName, r.IdleTimeout, safeIcon, safeAutoIcon, editSVG)
-		} else if r.Type == RouteSticky || r.Type == RouteBookmark {
-			safeExtURL := html.EscapeString(r.ExternalURL)
-			editType := "local"
-			if r.Type == RouteBookmark {
-				editType = "bookmark"
-			}
-			editBtn = fmt.Sprintf(`<button class="btn-icon" onclick="openEditModal('%s',%d,'%s','%s','%s','%s',%t,%t)" title="Edit">%s</button>`,
-				safeName, r.Port, safeExtURL, editType, safeIcon, safeAutoIcon, r.Proxy, r.InsecureSkipVerify, editSVG)
-		}
-
-		portDimStyle := ""
-		if isStopped {
-			portDimStyle = ` class="td-stopped"`
-		}
-
-		// Icon — user override > auto-detected > deterministic pool pick
-		icon := iconPool[nameHash(r.Name)%len(iconPool)]
-		if r.AutoIcon != "" {
-			icon = html.EscapeString(r.AutoIcon)
-		}
-		if r.Icon != "" {
-			icon = html.EscapeString(r.Icon)
-		}
-
-		iconClass := "route-icon"
-		if isStopped {
-			iconClass = "route-icon route-icon-stopped"
-		}
-
-		fmt.Fprintf(&b, `<tr>
-  <td><div class="route-name-cell"><span class="%s">%s</span><div><a href="%s" target="_blank" class="route-name-link">%s</a><span class="route-url">%s</span></div></div></td>
-  <td class="td-type">%s</td>
-  <td class="td-port"%s>%s</td>
-  <td class="td-age hide-mobile">%s</td>
-  <td><div class="td-actions">%s%s</div></td>
-</tr>`, iconClass, iconHTML(icon), vibeURL, safeName, urlDisplay,
-			typeLabel, portDimStyle, portCell, fmtDuration(since), actionHTML, editBtn)
-	}
-
-	if len(routes) == 0 {
-		b.WriteString(`</tbody></table>
-<div class="empty">No routes registered yet.</div>
-</div>`)
-	} else {
-		b.WriteString(`</tbody></table>
-</div>`)
-	}
-
-	// ── GRID VIEW ──
-	gridDisplay := "none"
-	if viewMode == "grid" {
-		gridDisplay = "block"
-	}
-	fmt.Fprintf(&b, `<div class="grid-view" id="grid-view" style="display:%s"><div class="grid-container">`, gridDisplay)
-
-	// Self tile
-	fmt.Fprintf(&b, `<a href="%s://local.%s/" class="grid-tile">
-  <div class="tile-icon"><span>&#127968;</span></div>
-  <div class="tile-name">local</div>
-  <div class="tile-url">local.%s</div>
-</a>`, scheme, tld, tld)
-
-	// Route tiles
-	for _, r := range routes {
-		safeName := html.EscapeString(r.Name)
-		vibeURL := fmt.Sprintf("%s://%s.%s", scheme, safeName, tld)
-
-		// URL display
-		urlDisplay := fmt.Sprintf("%s.%s", safeName, tld)
-		if r.Type == RouteBookmark {
-			urlDisplay = html.EscapeString(r.ExternalURL)
-		}
-
-		// Icon — user override > auto-detected > deterministic pool pick
-		icon := iconPool[nameHash(r.Name)%len(iconPool)]
-		if r.AutoIcon != "" {
-			icon = html.EscapeString(r.AutoIcon)
-		}
-		if r.Icon != "" {
-			icon = html.EscapeString(r.Icon)
-		}
-
-		// Stopped state — dim icon only, not text
-		isStopped := r.Type == RouteManaged && !r.Running.Load()
-		tileClass := "grid-tile"
-		if isStopped {
-			tileClass = "grid-tile tile-stopped"
-		}
-
-		fmt.Fprintf(&b, `<a href="%s" target="_blank" class="%s">
-  <div class="tile-icon">%s</div>
-  <div class="tile-name">%s</div>
-  <div class="tile-url">%s</div>
-</a>`, vibeURL, tileClass, iconHTML(icon), safeName, urlDisplay)
-	}
-
-	b.WriteString(`</div></div>`)
-
-	// Get Started section
-	fmt.Fprintf(&b, `
-<section class="get-started">
-  <h2>Get Started</h2>
-  <p>Paste this into Claude Code, Cursor, or any agentic IDE to configure a project with local.vibe.</p>
-  <div class="setup-box">
-    <textarea id="setup-text" class="setup-textarea" rows="5" readonly>This machine is running local.vibe, a local DNS tool that gives dev servers friendly .%[1]s names instead of hard-to-remember port numbers.
-
-Read the full setup instructions:
-
-  curl http://localhost:7999/setup.md
-
-Or open in a browser: %[2]s://local.%[1]s/setup.md</textarea>
-    <button class="btn-copy" id="copy-btn" onclick="copyText()">Copy</button>
-  </div>
-</section>
-</main>
-
-<!-- Add/Edit Modal -->
-<div class="modal-overlay" id="modal-overlay" onclick="if(event.target===this)closeModal()">
-<div class="modal">
-  <div class="modal-header">
-    <button type="button" class="icon-trigger" id="icon-preview" onclick="toggleIconPopover('route-popover',event)" title="Change icon">?</button>
-    <div class="modal-header-text">
-      <div class="modal-eyebrow" id="modal-title">Add Route</div>
-      <h3 id="modal-heading">New route</h3>
-      <div class="modal-sub" id="modal-sub">Map a friendly .vibe name to a local port or external URL.</div>
-    </div>
-  </div>
-  <div class="icon-popover" id="route-popover">
-    <input id="route-icon" type="hidden">
-    <div class="icon-popover-row">
-      <input id="route-icon-custom" type="text" placeholder="Paste any emoji…" oninput="onCustomIcon('route-icon','icon-preview','icon-clear','icon-picker')">
-      <button type="button" class="btn btn-sm" id="icon-clear" onclick="clearIcon('route-icon','icon-preview','icon-clear','icon-picker')" style="display:none">Clear</button>
-    </div>
-    <div class="icon-picker" id="icon-picker"></div>
-  </div>
-  <div class="modal-body">
-    <div class="type-toggle" id="type-toggle">
-      <button id="toggle-local" class="active" onclick="setRouteType('local')">Local Port</button>
-      <button id="toggle-bookmark" onclick="setRouteType('bookmark')">External URL</button>
-    </div>
-    <div class="field-row">
-      <div class="field">
-        <label for="route-name">Name</label>
-        <input id="route-name" type="text" placeholder="myapp" autocomplete="off" oninput="updateModalHeading()">
-      </div>
-      <div id="port-field" class="field field-port">
-        <label for="route-port">Port</label>
-        <input id="route-port" type="number" placeholder="3000">
-      </div>
-    </div>
-    <div id="url-field" class="field" style="display:none">
-      <label for="route-url">URL</label>
-      <input id="route-url" type="text" placeholder="example.com:8080">
-    </div>
-    <div id="options-card" class="options-card" style="display:none">
-      <div id="proxy-field" class="opt">
-        <label class="checkbox-row">
-          <input id="route-proxy" type="checkbox" onchange="onProxyToggle()">
-          <span>Proxy instead of redirect</span>
-        </label>
-        <p class="hint">Keep <code>.vibe</code> in the browser URL. Useful for mirroring Tailscale or intranet hosts on a friendly name.</p>
-      </div>
-      <div id="insecure-field" class="opt" style="display:none">
-        <label class="checkbox-row">
-          <input id="route-insecure" type="checkbox">
-          <span>Allow self-signed TLS cert</span>
-        </label>
-        <p class="hint">Only enable when the upstream uses an untrusted certificate (e.g. Tailscale MagicDNS).</p>
-      </div>
-    </div>
-  </div>
-  <div class="modal-actions">
-    <button class="btn btn-danger" id="modal-delete" style="display:none;margin-right:auto" onclick="deleteRoute()">Delete route</button>
-    <button class="btn" onclick="closeModal()">Cancel</button>
-    <button class="btn-add" id="modal-save" onclick="saveRoute()">Add</button>
-  </div>
-</div>
-</div>
-<!-- Managed Route Settings Modal -->
-<div class="modal-overlay" id="managed-overlay" onclick="if(event.target===this)closeManagedModal()">
-<div class="modal">
-  <div class="modal-header">
-    <button type="button" class="icon-trigger" id="managed-icon-preview" onclick="toggleIconPopover('managed-popover',event)" title="Change icon">?</button>
-    <div class="modal-header-text">
-      <div class="modal-eyebrow">Managed Route</div>
-      <h3 id="managed-heading">Settings</h3>
-      <div class="modal-sub">Configure a daemon-managed process.</div>
-    </div>
-  </div>
-  <div class="icon-popover" id="managed-popover">
-    <input id="managed-icon" type="hidden">
-    <div class="icon-popover-row">
-      <input id="managed-icon-custom" type="text" placeholder="Paste any emoji…" oninput="onCustomIcon('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker')">
-      <button type="button" class="btn btn-sm" id="managed-icon-clear" onclick="clearIcon('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker')" style="display:none">Clear</button>
-    </div>
-    <div class="icon-picker" id="managed-icon-picker"></div>
-  </div>
-  <div class="modal-body">
-    <div class="field">
-      <label for="managed-name">Name</label>
-      <input id="managed-name" type="text" placeholder="myapp" autocomplete="off" oninput="updateManagedHeading()">
-    </div>
-    <div class="field">
-      <label for="idle-timeout">Auto-stop after idle (minutes)</label>
-      <input id="idle-timeout" type="number" min="0" placeholder="0 = never">
-      <p class="hint">Stop the process automatically when no traffic is received. Set to <code>0</code> to disable.</p>
-    </div>
-  </div>
-  <div class="modal-actions">
-    <button class="btn btn-danger" style="margin-right:auto" onclick="deleteManagedRoute()">Delete route</button>
-    <button class="btn" onclick="closeManagedModal()">Cancel</button>
-    <button class="btn-add" onclick="saveManagedSettings()">Save</button>
-  </div>
-</div>
-</div>
-<script>
-// View toggle
-function setView(mode,save){
-  var l=document.getElementById('list-view'),g=document.getElementById('grid-view');
-  var bl=document.getElementById('btn-list'),bg=document.getElementById('btn-grid');
-  if(mode==='grid'){l.style.display='none';g.style.display='block';bl.classList.remove('active');bg.classList.add('active')}
-  else{l.style.display='block';g.style.display='none';bl.classList.add('active');bg.classList.remove('active')}
-  if(save)fetch('/_api/preferences',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({view:mode})});
-}
-
-var modalMode='add';
-var editingName='';
-function setRouteType(t){
-  var modal=document.querySelector('#modal-overlay .modal');
-  var animate=modal&&document.getElementById('modal-overlay').classList.contains('active');
-  var fromH=animate?modal.offsetHeight:0;
-  document.getElementById('toggle-local').className=t==='local'?'active':'';
-  document.getElementById('toggle-bookmark').className=t==='bookmark'?'active':'';
-  document.getElementById('port-field').style.display=t==='local'?'':'none';
-  document.getElementById('url-field').style.display=t==='bookmark'?'':'none';
-  document.getElementById('proxy-field').style.display=t==='bookmark'?'':'none';
-  document.getElementById('options-card').style.display=t==='bookmark'?'':'none';
-  onProxyToggle();
-  if(animate){
-    var toH=modal.offsetHeight;
-    if(toH!==fromH){
-      modal.style.transition='none';
-      modal.style.height=fromH+'px';
-      modal.offsetHeight;
-      modal.style.transition='height .3s cubic-bezier(.4,0,.2,1)';
-      modal.style.height=toH+'px';
-      setTimeout(function(){modal.style.transition='';modal.style.height=''},320);
-    }
-  }
-}
-function onProxyToggle(){
-  var proxyOn=document.getElementById('route-proxy').checked;
-  var bookmark=document.getElementById('toggle-bookmark').className==='active';
-  document.getElementById('insecure-field').style.display=(bookmark&&proxyOn)?'':'none';
-}
-function updateModalHeading(){
-  var n=document.getElementById('route-name').value.trim();
-  document.getElementById('modal-heading').textContent=n?n+'.vibe':(modalMode==='edit'?'Edit route':'New route');
-}
-function updateManagedHeading(){
-  var n=document.getElementById('managed-name').value.trim();
-  document.getElementById('managed-heading').textContent=n?n+'.vibe':'Settings';
-}
-function openAddModal(){
-  modalMode='add';editingName='';
-  document.getElementById('modal-title').textContent='Add Route';
-  document.getElementById('modal-heading').textContent='New route';
-  document.getElementById('modal-sub').textContent='Map a friendly .vibe name to a local port or external URL.';
-  document.getElementById('modal-save').textContent='Add Route';
-  document.getElementById('modal-delete').style.display='none';
-  document.getElementById('type-toggle').style.display='';
-  document.getElementById('route-name').value='';
-  document.getElementById('route-name').disabled=false;
-  document.getElementById('route-port').value='';
-  document.getElementById('route-url').value='';
-  document.getElementById('route-proxy').checked=false;
-  document.getElementById('route-insecure').checked=false;
-  setIconField('route-icon','icon-preview','icon-clear','icon-picker','');
-  setRouteType('local');
-  document.getElementById('modal-overlay').classList.add('active');
-}
-function openEditModal(name,port,url,type,icon,autoIcon,proxy,insecure){
-  modalMode='edit';editingName=name;
-  document.getElementById('modal-title').textContent='Edit Route';
-  document.getElementById('modal-heading').textContent=name+'.vibe';
-  document.getElementById('modal-sub').textContent=type==='bookmark'?'Reverse-proxy or redirect to an external host.':'Forward .vibe traffic to a local port.';
-  document.getElementById('modal-save').textContent='Save';
-  document.getElementById('modal-delete').style.display='';
-  document.getElementById('type-toggle').style.display='';
-  document.getElementById('route-name').value=name;
-  document.getElementById('route-name').disabled=false;
-  document.getElementById('route-icon').dataset.autoicon=autoIcon||'';
-  setIconField('route-icon','icon-preview','icon-clear','icon-picker',icon||'',autoIcon||'');
-  document.getElementById('route-proxy').checked=!!proxy;
-  document.getElementById('route-insecure').checked=!!insecure;
-  if(type==='bookmark'){
-    setRouteType('bookmark');
-    document.getElementById('route-url').value=url;
-    document.getElementById('route-port').value='';
-  }else{
-    setRouteType('local');
-    document.getElementById('route-port').value=port||'';
-    document.getElementById('route-url').value='';
-  }
-  document.getElementById('modal-overlay').classList.add('active');
-}
-function closeModal(){document.getElementById('modal-overlay').classList.remove('active');closeAllIconPopovers()}
-function saveRoute(){
-  var name=document.getElementById('route-name').value.trim();
-  if(!name)return;
-  var isBookmark=document.getElementById('toggle-bookmark').className==='active';
-  var body={name:name,icon:getIconValue('route-icon')};
-  if(isBookmark){
-    var u=document.getElementById('route-url').value.trim();
-    if(!u)return;
-    if(u.indexOf('://')===-1)u='http://'+u;
-    body.url=u;
-    body.proxy=document.getElementById('route-proxy').checked;
-    body.insecure_skip_verify=document.getElementById('route-insecure').checked;
-  }else{
-    var p=parseInt(document.getElementById('route-port').value);
-    if(!p)return;
-    body.port=p;
-    body.proxy=false;
-    body.insecure_skip_verify=false;
-  }
-  if(modalMode==='edit'){
-    fetch('/_api/routes/'+encodeURIComponent(editingName),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(function(){location.reload()});
-  }else{
-    fetch('/_api/routes',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(function(){location.reload()});
-  }
-}
-function deleteRoute(){
-  if(!editingName)return;
-  fetch('/_api/routes/'+encodeURIComponent(editingName),{method:'DELETE',headers:{'Accept':'application/json'}}).then(function(){location.reload()});
-}
-function copyText(){
-  var ta=document.getElementById('setup-text');
-  var btn=document.getElementById('copy-btn');
-  if(navigator.clipboard&&window.isSecureContext){
-    navigator.clipboard.writeText(ta.value).then(function(){
-      btn.textContent='Copied';setTimeout(function(){btn.textContent='Copy'},1500);
-    });
-  }else{
-    ta.select();document.execCommand('copy');window.getSelection().removeAllRanges();
-    btn.textContent='Copied';setTimeout(function(){btn.textContent='Copy'},1500);
-  }
-}
-var managedEditName='';
-function openManagedModal(name,idle,icon,autoIcon){
-  managedEditName=name;
-  document.getElementById('managed-heading').textContent=name+'.vibe';
-  document.getElementById('managed-name').value=name;
-  document.getElementById('idle-timeout').value=idle||'';
-  document.getElementById('managed-icon').dataset.autoicon=autoIcon||'';
-  setIconField('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker',icon||'',autoIcon||'');
-  document.getElementById('managed-overlay').classList.add('active');
-}
-function closeManagedModal(){document.getElementById('managed-overlay').classList.remove('active');closeAllIconPopovers()}
-function deleteManagedRoute(){
-  if(!managedEditName)return;
-  fetch('/_api/routes/'+encodeURIComponent(managedEditName),{method:'DELETE',headers:{'Accept':'application/json'}}).then(function(){location.reload()});
-}
-function saveManagedSettings(){
-  var name=document.getElementById('managed-name').value.trim();
-  if(!name)return;
-  var idle=parseInt(document.getElementById('idle-timeout').value)||0;
-  var body={name:name,idle_timeout:idle,icon:getIconValue('managed-icon')};
-  fetch('/_api/routes/'+encodeURIComponent(managedEditName),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(function(){location.reload()});
-}
-function setIconField(inputId,previewId,clearId,pickerId,val,autoIcon){
-  var inp=document.getElementById(inputId);
-  inp.value=val||'';
-  if(autoIcon!==undefined)inp.dataset.autoicon=autoIcon;
-  var display=val||inp.dataset.autoicon||'';
-  setIconPreviewEl(document.getElementById(previewId),display);
-  document.getElementById(clearId).style.display=val?'':'none';
-  var customInp=document.getElementById(inputId+'-custom');
-  if(customInp&&!val)customInp.value='';
-  highlightPicker(pickerId,val||'');
-}
-function getIconValue(inputId){return document.getElementById(inputId).value}
-function clearIcon(inputId,previewId,clearId,pickerId){
-  var autoIcon=document.getElementById(inputId).dataset.autoicon||'';
-  document.getElementById(inputId+'-custom').value='';
-  setIconField(inputId,previewId,clearId,pickerId,'',autoIcon);
-}
-function onCustomIcon(inputId,previewId,clearId,pickerId){
-  var val=document.getElementById(inputId+'-custom').value.trim();
-  setIconField(inputId,previewId,clearId,pickerId,val);
-}
-var iconChoices=['🚀','🤖','📦','⚡','🔮','🎯','🛠️','💎','🧪','🌐','📡','🎨','🔒','🗂️','📊','🧩'];
-function buildPicker(containerId,inputId,previewId,clearId,popoverId){
-  var c=document.getElementById(containerId);
-  c.innerHTML='';
-  iconChoices.forEach(function(em){
-    var b=document.createElement('button');
-    b.type='button';b.className='icon-pick';b.textContent=em;
-    b.onclick=function(){
-      setIconField(inputId,previewId,clearId,containerId,em);
-      if(popoverId)closeIconPopover(popoverId);
-    };
-    c.appendChild(b);
-  });
-}
-function toggleIconPopover(id,e){
-  if(e){e.stopPropagation()}
-  var p=document.getElementById(id);
-  var wasOpen=p.classList.contains('active');
-  closeAllIconPopovers();
-  if(!wasOpen)p.classList.add('active');
-}
-function closeIconPopover(id){document.getElementById(id).classList.remove('active')}
-function closeAllIconPopovers(){
-  document.querySelectorAll('.icon-popover.active').forEach(function(p){p.classList.remove('active')});
-}
-document.addEventListener('click',function(e){
-  if(e.target.closest('.icon-popover')||e.target.closest('.icon-trigger'))return;
-  closeAllIconPopovers();
-});
-function highlightPicker(containerId,val){
-  var btns=document.getElementById(containerId).querySelectorAll('.icon-pick');
-  btns.forEach(function(b){b.classList.toggle('selected',b.textContent===val)});
-}
-buildPicker('icon-picker','route-icon','icon-preview','icon-clear','route-popover');
-buildPicker('managed-icon-picker','managed-icon','managed-icon-preview','managed-icon-clear','managed-popover');
-
-function setIconPreviewEl(el,val){
-  if(!val){el.textContent='?';el.style.backgroundImage='';return}
-  if(val.startsWith('data:')||val.startsWith('http://')||val.startsWith('https://')){
-    el.textContent='';el.style.backgroundImage='url('+val+')';
-    el.style.backgroundSize='cover';el.style.backgroundPosition='center';
-  }else{
-    el.style.backgroundImage='';el.textContent=val;
-  }
-}
-function routeAction(btn,name,action){
-  var origText=btn.textContent;
-  btn.disabled=true;
-  btn.innerHTML='<span class="spinner"></span>';
-  fetch('/_api/routes/'+encodeURIComponent(name)+'/'+action,{method:'POST',headers:{'Accept':'application/json'}})
-    .then(function(r){
-      if(!r.ok)return r.json().then(function(d){throw new Error(d.error||'Request failed')});
-      return r.json();
-    })
-    .then(function(){
-      if(action==='start'){pollReady(name,0)}
-      else{pollStopped(name,0)}
-    })
-    .catch(function(e){
-      btn.disabled=false;btn.textContent=origText;
-      showToast(e.message||'Action failed');
-    });
-}
-function pollStopped(name,n){
-  if(n>20){location.reload();return}
-  fetch('/_api/routes/'+encodeURIComponent(name)+'/ready')
-    .then(function(r){return r.json()})
-    .then(function(d){
-      if(!d.ready){location.reload()}
-      else{setTimeout(function(){pollStopped(name,n+1)},300)}
-    })
-    .catch(function(){location.reload()});
-}
-function pollReady(name,n){
-  if(n>60){location.reload();return}
-  fetch('/_api/routes/'+encodeURIComponent(name)+'/ready')
-    .then(function(r){return r.json()})
-    .then(function(d){
-      if(d.ready){location.reload()}
-      else if(d.running===false){showToast(name+' crashed during startup');location.reload()}
-      else{setTimeout(function(){pollReady(name,n+1)},500)}
-    })
-    .catch(function(){setTimeout(function(){pollReady(name,n+1)},500)});
-}
-function showToast(msg){
-  var el=document.createElement('div');el.className='toast';el.textContent=msg;
-  document.body.appendChild(el);
-  setTimeout(function(){el.classList.add('show')},10);
-  setTimeout(function(){el.classList.remove('show');setTimeout(function(){el.remove()},300)},4000);
-}
-document.addEventListener('keydown',function(e){if(e.key==='Escape'){closeModal();closeManagedModal()}});
-document.addEventListener('visibilitychange',function(){if(!document.hidden){location.reload()}});
-</script>
-`, tld, scheme)
-
-	// Footer
-	fmt.Fprintf(&b, `<footer class="footer">
-  <span>daemon :%d</span>
-  <span class="footer-sep">|</span>
-  <a href="/_api/routes">API</a>
-  <span class="footer-sep">|</span>
-  <a href="/_api/health">Health</a>
-</footer>
-`, port)
-
-	b.WriteString(`</body></html>`)
-	fmt.Fprint(w, b.String())
-}
-
-func pluralS(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
 }
 
 // nameHash returns a stable hash for a route name, used to pick a default icon.
@@ -842,14 +174,6 @@ func nameHash(name string) int {
 		h = -h
 	}
 	return h
-}
-
-// iconHTML returns the icon as either an emoji span or an <img> tag for URLs/data URIs.
-func iconHTML(icon string) string {
-	if strings.HasPrefix(icon, "data:") || strings.HasPrefix(icon, "http://") || strings.HasPrefix(icon, "https://") {
-		return fmt.Sprintf(`<img src="%s" style="width:100%%;height:100%%;object-fit:contain;border-radius:inherit" onerror="this.style.display='none';this.parentElement.textContent='🔲'">`, html.EscapeString(icon))
-	}
-	return icon
 }
 
 func fmtDuration(d time.Duration) string {

--- a/internal/daemon/repairpage.go
+++ b/internal/daemon/repairpage.go
@@ -2,172 +2,36 @@ package daemon
 
 import (
 	"fmt"
-	"html"
+	"html/template"
 	"net/http"
 )
+
+type repairPageData struct {
+	Head template.HTML
+	CSS  template.CSS
+	Name string
+	TLD  string
+	Port int
+}
 
 // serveRepairPage renders a "reconnecting..." page for a route whose
 // registered port is no longer answering. The page polls
 // /_api/routes/{name}/repair in the background; on a successful hit the
 // daemon silently rewrites the route's port and the page reloads into a
-// working proxy. On failure it offers a Restart button for managed
-// routes (when the child process is gone) or a link back to the
-// dashboard.
+// working proxy.
 func (s *Server) serveRepairPage(w http.ResponseWriter, _ *http.Request, route *Route) {
 	tld := s.cfg.Daemon.TLD
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	safeName := html.EscapeString(route.Name)
-	safeTLD := html.EscapeString(tld)
-	safePort := route.Port
+	data := repairPageData{
+		Head: template.HTML(themeHead(route.Name + "." + tld)),
+		CSS:  template.CSS(themeCSS),
+		Name: route.Name,
+		TLD:  tld,
+		Port: route.Port,
+	}
 
-	fmt.Fprintf(w, `<!DOCTYPE html>
-<html lang="en">
-<head>
-%s
-<style>%s
-
-/* Repair page */
-body{display:flex;align-items:center;justify-content:center}
-.card{
-  background:var(--surface);border:1px solid var(--border);
-  border-radius:var(--radius-lg);padding:40px;max-width:440px;width:100%%;
-  text-align:center;
-  box-shadow:0 16px 48px rgba(0,0,0,.4);
-  animation:fade-in .2s ease;
-}
-@keyframes fade-in{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}
-h1{font-family:var(--font-display);font-size:1.1rem;font-weight:400;color:var(--yellow);margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em}
-.url{font-size:.85rem;color:var(--text-muted);margin-bottom:8px}
-.status{display:flex;align-items:center;justify-content:center;gap:6px;font-size:.8rem;color:var(--text-muted);margin-bottom:20px;text-transform:uppercase;letter-spacing:.06em}
-.status .led{display:inline-block;width:8px;height:8px;border-radius:50%%;background:var(--yellow);box-shadow:0 0 8px var(--yellow-glow);animation:pulse 1.2s ease-in-out infinite}
-@keyframes pulse{0%%,100%%{opacity:.4}50%%{opacity:1}}
-.hint{
-  background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);
-  padding:10px 14px;font-family:var(--font-body);font-size:.8rem;color:var(--text-secondary);
-  margin-bottom:20px;text-align:left;line-height:1.5;
-}
-.hint .label{color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-size:.72rem;margin-bottom:4px}
-.hint code{color:var(--amber);font-family:var(--font-body)}
-.page-spinner{
-  display:block;margin:0 auto 14px;width:22px;height:22px;
-  border:1.5px solid #333;border-top-color:var(--yellow);
-  border-radius:50%%;animation:spin 1s linear infinite;
-}
-.msg{color:var(--text-muted);font-size:.8rem;margin-top:4px}
-.actions{display:none;flex-direction:column;gap:10px;margin-top:18px}
-.btn{
-  background:var(--amber);color:var(--bg);border:none;border-radius:var(--radius);
-  padding:10px 24px;font-size:.82rem;font-family:var(--font-body);font-weight:600;
-  cursor:pointer;text-transform:uppercase;letter-spacing:.06em;transition:all .15s;
-}
-.btn:hover{background:#f0a048;box-shadow:0 0 12px var(--amber-glow)}
-.btn:disabled{background:var(--surface);color:var(--text-muted);cursor:default;border:1px solid var(--border);box-shadow:none}
-.btn.secondary{background:transparent;border:1px solid var(--border);color:var(--text-secondary)}
-.btn.secondary:hover{border-color:var(--text-secondary);color:var(--text);box-shadow:none;background:var(--elevated)}
-.error{color:var(--red);font-size:.8rem;margin-top:10px;white-space:pre-wrap;text-align:left}
-</style>
-</head>
-<body>
-<div class="card">
-  <h1>%[3]s</h1>
-  <div class="url">%[3]s.%[4]s</div>
-  <div class="status"><span class="led"></span>Reconnecting</div>
-  <div class="hint">
-    <div class="label">Port %[5]d not responding</div>
-    Looking for the app in logs and process listings&hellip;
-  </div>
-  <div class="page-spinner" id="spinner"></div>
-  <div class="msg" id="msg">Probing&hellip;</div>
-  <div class="actions" id="actions"></div>
-  <div class="error" id="error" style="display:none"></div>
-</div>
-<script>
-var attempts=0;
-var maxAttempts=30;
-
-function showActions(html){
-  var box=document.getElementById('actions');
-  box.innerHTML=html;
-  box.style.display='flex';
-}
-
-function giveUp(reason, restartable){
-  document.getElementById('spinner').style.display='none';
-  var msg=document.getElementById('msg');
-  msg.textContent='Could not recover automatically';
-  msg.style.color='var(--red)';
-  var err=document.getElementById('error');
-  err.textContent=reason||'No listening port found nearby.';
-  err.style.display='block';
-  var buttons='';
-  if(restartable){
-    buttons+='<button class="btn" onclick="restartApp()">Restart app</button>';
-  }
-  buttons+='<button class="btn secondary" onclick="window.location.reload()">Retry</button>';
-  buttons+='<a class="btn secondary" href="/" style="text-decoration:none;display:inline-block">Dashboard</a>';
-  showActions(buttons);
-}
-
-function restartApp(){
-  var btns=document.querySelectorAll('#actions .btn');
-  btns.forEach(function(b){b.disabled=true;});
-  document.getElementById('spinner').style.display='block';
-  document.getElementById('msg').style.color='';
-  document.getElementById('msg').textContent='Restarting\u2026';
-  document.getElementById('error').style.display='none';
-  document.getElementById('actions').style.display='none';
-  var xhr=new XMLHttpRequest();
-  xhr.open('POST','/_api/routes/%[3]s/start');
-  xhr.setRequestHeader('Accept','application/json');
-  xhr.onload=function(){
-    if(xhr.status===200){
-      // Fall back into the poll loop — the repair endpoint will see the new listener.
-      attempts=0;
-      setTimeout(pollRepair,500);
-    }else{
-      var err='Failed to start';
-      try{var d=JSON.parse(xhr.responseText);if(d&&d.error)err=d.error;}catch(e){}
-      giveUp(err, true);
-    }
-  };
-  xhr.onerror=function(){giveUp('Could not reach daemon', true);};
-  xhr.send();
-}
-
-function pollRepair(){
-  if(attempts>=maxAttempts){
-    giveUp('Still no listener after '+Math.round(maxAttempts*0.5)+'s. The app may have crashed.', false);
-    return;
-  }
-  attempts++;
-  var xhr=new XMLHttpRequest();
-  xhr.open('GET','/_api/routes/%[3]s/repair');
-  xhr.timeout=2500;
-  xhr.onload=function(){
-    var d=null;
-    try{d=JSON.parse(xhr.responseText);}catch(e){}
-    if(d&&d.ok){
-      document.getElementById('msg').textContent='Found it \u2014 reloading';
-      document.getElementById('msg').style.color='var(--green)';
-      setTimeout(function(){window.location.href=window.location.href;},250);
-      return;
-    }
-    if(d&&d.restartable){
-      giveUp(d.reason||'Process is not running.', true);
-      return;
-    }
-    // Keep trying for a bit; the app may still be starting up.
-    setTimeout(pollRepair,500);
-  };
-  xhr.onerror=function(){setTimeout(pollRepair,500);};
-  xhr.ontimeout=function(){setTimeout(pollRepair,500);};
-  xhr.send();
-}
-
-pollRepair();
-</script>
-</body>
-</html>
-`, themeHead(route.Name+"."+tld), themeCSS, safeName, safeTLD, safePort)
+	if err := tmplRepairPage.Execute(w, data); err != nil {
+		fmt.Fprintf(w, "\n<!-- template error: %v -->\n", err)
+	}
 }

--- a/internal/daemon/startpage.go
+++ b/internal/daemon/startpage.go
@@ -3,381 +3,43 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
-	"html"
+	"html/template"
 	"net/http"
 	"path/filepath"
 )
 
+// startPageData feeds templates/startpage.html.tmpl. RecoveryInit is
+// JSON-serialized JavaScript (or empty) that fires showRecovery(...) on
+// load when the route already has a known-bad signal — so users see the
+// "Kill PID X and retry" affordance without having to click Start first.
+type startPageData struct {
+	Head         template.HTML
+	CSS          template.CSS
+	Name         string
+	TLD          string
+	Cmd          string
+	RecoveryInit template.JS
+}
+
 // serveStartPage renders a "not running" page for managed routes whose process
-// has stopped. It offers a Start button that launches the process and polls
-// until the port is accepting connections, then reloads.
-//
-// If the route has a stored Failure with a Recovery hint (or the log tail
-// still reveals one after a daemon restart wiped the in-memory state), the
-// recovery section is rendered visibly on page load so the user sees the
-// "Kill PID X and retry" button without having to click Start first.
+// has stopped. The page offers a Start button and polls /ready until the port
+// accepts connections.
 func (s *Server) serveStartPage(w http.ResponseWriter, _ *http.Request, route *Route) {
 	tld := s.cfg.Daemon.TLD
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	// Route names are already validated to [a-z0-9-], but we escape on output
-	// defensively so this template is safe against any future relaxation. Cmd
-	// is free-form user input and MUST be escaped before HTML injection.
-	safeName := html.EscapeString(route.Name)
-	safeTLD := html.EscapeString(tld)
-	safeCmd := html.EscapeString(route.Cmd)
+	data := startPageData{
+		Head:         template.HTML(themeHead(route.Name + "." + tld)),
+		CSS:          template.CSS(themeCSS),
+		Name:         route.Name,
+		TLD:          tld,
+		Cmd:          route.Cmd,
+		RecoveryInit: template.JS(s.startPageRecoveryInitJS(route)),
+	}
 
-	initRecovery := s.startPageRecoveryInitJS(route)
-
-	fmt.Fprintf(w, `<!DOCTYPE html>
-<html lang="en">
-<head>
-%s
-<style>%s
-
-/* Start page */
-body{display:flex;align-items:center;justify-content:center}
-.card{
-  background:var(--surface);border:1px solid var(--border);
-  border-radius:var(--radius-lg);padding:40px;max-width:420px;width:100%%;
-  text-align:center;
-  box-shadow:0 16px 48px rgba(0,0,0,.4);
-  animation:fade-in .2s ease;
-}
-@keyframes fade-in{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}
-h1{font-family:var(--font-display);font-size:1.1rem;font-weight:400;color:var(--amber);margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em}
-.url{font-size:.85rem;color:var(--text-muted);margin-bottom:8px}
-.status{display:flex;align-items:center;justify-content:center;gap:6px;font-size:.8rem;color:var(--text-muted);margin-bottom:24px;text-transform:uppercase;letter-spacing:.06em}
-.cmd{
-  background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);
-  padding:10px 14px;font-family:var(--font-body);font-size:.8rem;color:var(--text-secondary);
-  margin-bottom:24px;text-align:left;word-break:break-all;
-}
-.start-btn{
-  background:var(--amber);color:var(--bg);border:none;border-radius:var(--radius);
-  padding:10px 32px;font-size:.85rem;font-family:var(--font-body);font-weight:600;
-  cursor:pointer;text-transform:uppercase;letter-spacing:.06em;transition:all .15s;
-}
-.start-btn:hover{background:#f0a048;box-shadow:0 0 12px var(--amber-glow)}
-.start-btn:disabled{background:var(--surface);color:var(--text-muted);cursor:default;border:1px solid var(--border);box-shadow:none}
-.page-spinner{
-  display:none;margin:16px auto 0;width:20px;height:20px;
-  border:1.5px solid #333;border-top-color:#888;
-  border-radius:50%%;animation:spin .6s linear infinite;
-}
-.msg{color:var(--text-muted);font-size:.8rem;margin-top:10px;display:none}
-.recovery{
-  display:none;margin-top:16px;padding:14px;
-  background:rgba(239,68,68,.06);border:1px solid rgba(239,68,68,.25);
-  border-radius:var(--radius);text-align:left;
-}
-.recovery-msg{font-size:.82rem;color:var(--text-secondary);margin-bottom:10px;line-height:1.4}
-.recovery-btn{
-  background:var(--red,#ef4444);color:#fff;border:none;border-radius:var(--radius);
-  padding:8px 16px;font-size:.78rem;font-family:var(--font-body);font-weight:600;
-  cursor:pointer;text-transform:uppercase;letter-spacing:.06em;transition:all .15s;
-}
-.recovery-btn:hover{filter:brightness(1.1)}
-.recovery-btn:disabled{opacity:.5;cursor:default}
-.log-tail{
-  margin-top:10px;padding:8px;background:var(--bg);border:1px solid var(--border);
-  border-radius:var(--radius);font-family:var(--font-body);font-size:.72rem;
-  color:var(--text-muted);white-space:pre-wrap;max-height:160px;overflow:auto;
-}
-</style>
-</head>
-<body>
-<div class="card">
-  <h1>%[3]s</h1>
-  <div class="url">%[3]s.%[4]s</div>
-  <div class="status"><span class="led led-red"></span>Stopped</div>
-  <div class="cmd">%[5]s</div>
-  <button class="start-btn" id="btn" onclick="handlePrimaryButton()">Cancel</button>
-  <div class="page-spinner" id="spinner" style="display:block"></div>
-  <div class="msg" id="msg" style="display:block;color:var(--text-muted)">Launching process…</div>
-  <div class="recovery" id="recovery">
-    <div class="recovery-msg" id="recovery-msg"></div>
-    <button class="recovery-btn" id="recovery-btn" onclick="recoverAndRetry()"></button>
-    <div class="log-tail" id="log-tail" style="display:none"></div>
-  </div>
-</div>
-<script>
-var lastRecovery=null;
-var launchCanceled=false;
-var activeXHR=null;
-var launchMode='cancel'; // cancel | retry
-
-function setLaunchMode(mode){
-  launchMode=mode;
-  var btn=document.getElementById('btn');
-  if(mode==='cancel'){
-    btn.disabled=false;
-    btn.textContent='Cancel';
-    return;
-  }
-  btn.disabled=false;
-  btn.textContent='Retry';
-}
-
-function handlePrimaryButton(){
-  if(launchMode==='cancel'){
-    cancelLaunch();
-    return;
-  }
-  startApp();
-}
-
-// fetchFailureAndRender pulls the most recent Failure off /ready and renders
-// it on the page. Retries up to 3 times at 1s intervals to cover the race
-// where the frontend poll timeout fires a beat before waitForReady writes
-// its failure record.
-function fetchFailureAndRender(tries){
-  var msg=document.getElementById('msg');
-  var spinner=document.getElementById('spinner');
-  var fx=new XMLHttpRequest();
-  fx.open('GET','/_api/routes/%[3]s/ready');
-  fx.timeout=2000;
-  fx.onload=function(){
-    var d=null;try{d=JSON.parse(fx.responseText);}catch(e){}
-    if(d&&d.failure){
-      setLaunchMode('retry');spinner.style.display='none';
-      msg.style.whiteSpace='pre-wrap';msg.style.textAlign='left';msg.style.fontSize='.75rem';
-      msg.textContent=d.failure.message||'Server never became ready';
-      msg.style.color='var(--red)';
-      if(d.failure.recovery){showRecovery(d.failure.recovery, d.failure.log||'');}
-      else if(d.failure.log){showFailureLog(d.failure.log);}
-      return;
-    }
-    if(tries<3){setTimeout(function(){fetchFailureAndRender(tries+1);},1000);return;}
-    setLaunchMode('retry');spinner.style.display='none';
-    msg.textContent='Taking too long \u2014 check logs';
-    msg.style.color='var(--yellow)';
-  };
-  fx.onerror=fx.ontimeout=function(){
-    if(tries<3){setTimeout(function(){fetchFailureAndRender(tries+1);},1000);return;}
-    setLaunchMode('retry');spinner.style.display='none';
-    msg.textContent='Taking too long \u2014 check logs';
-    msg.style.color='var(--yellow)';
-  };
-  fx.send();
-}
-
-function hideRecovery(){
-  document.getElementById('recovery').style.display='none';
-  lastRecovery=null;
-}
-
-function showRecovery(rec, logTail){
-  lastRecovery=rec;
-  var box=document.getElementById('recovery');
-  var btn=document.getElementById('recovery-btn');
-  document.getElementById('recovery-msg').textContent=rec.message||'Recoverable error';
-  var logEl=document.getElementById('log-tail');
-  // "info" actions are diagnostic only (e.g., missing pip module) — render
-  // the message + log tail with no button, since the fix requires user input.
-  if(rec.action==='info'){
-    btn.style.display='none';
-  }else{
-    btn.style.display='inline-flex';
-    btn.disabled=false;
-    var label='Kill and Retry';
-    if(rec.action==='kill_pid' && rec.pid) label='Kill PID '+rec.pid+' and Retry';
-    else if(rec.action==='kill_port' && rec.port) label='Free Port '+rec.port+' and Retry';
-    else if(rec.action==='restart') label=(rec.pid?'Restart Process (PID '+rec.pid+')':'Restart Process');
-    else if(rec.action==='edit_cmd' && rec.suggested_cmd) label='Use \u0060'+rec.suggested_cmd+'\u0060 and Retry';
-    btn.textContent=label;
-  }
-  if(logTail){logEl.textContent=logTail;logEl.style.display='block';}else{logEl.style.display='none';}
-  box.style.display='block';
-}
-
-function showFailureLog(logTail){
-  lastRecovery=null;
-  var box=document.getElementById('recovery');
-  var btn=document.getElementById('recovery-btn');
-  var logEl=document.getElementById('log-tail');
-  document.getElementById('recovery-msg').textContent='No automatic recovery available. See log tail:';
-  btn.style.display='none';
-  if(logTail){logEl.textContent=logTail;logEl.style.display='block';}else{logEl.style.display='none';}
-  box.style.display='block';
-}
-
-function startApp(body){
-  launchCanceled=false;
-  hideRecovery();
-  var spinner=document.getElementById('spinner');
-  var msg=document.getElementById('msg');
-  setLaunchMode('cancel');
-  spinner.style.display='block';
-  msg.style.display='block';
-  msg.style.color='var(--text-muted)';
-  msg.style.whiteSpace='normal';msg.style.textAlign='center';msg.style.fontSize='.8rem';
-  msg.textContent='Launching process\u2026';
-
-  var xhr=new XMLHttpRequest();
-  activeXHR=xhr;
-  xhr.open('POST','/_api/routes/%[3]s/start');
-  xhr.setRequestHeader('Accept','application/json');
-  if(body){xhr.setRequestHeader('Content-Type','application/json');}
-  xhr.onload=function(){
-    activeXHR=null;
-    if(launchCanceled){return;}
-    if(xhr.status===200){
-      msg.textContent='Waiting for server\u2026';
-      pollUntilReady(0);
-    }else{
-      setLaunchMode('retry');
-      spinner.style.display='none';
-      var errMsg='Failed to start';
-      var d=null;
-      try{d=JSON.parse(xhr.responseText);if(d&&d.error)errMsg=d.error;}catch(e){}
-      msg.style.whiteSpace='pre-wrap';msg.style.textAlign='left';msg.style.fontSize='.75rem';
-      msg.textContent=errMsg;
-      msg.style.color='var(--red)';
-      if(d&&d.recovery){showRecovery(d.recovery, d.log||'');}
-      else if(d&&d.log){showFailureLog(d.log);}
-    }
-  };
-  xhr.onerror=function(){
-    activeXHR=null;
-    if(launchCanceled){return;}
-    setLaunchMode('retry');
-    spinner.style.display='none';
-    msg.textContent='Could not reach daemon';
-    msg.style.color='var(--red)';
-  };
-  xhr.send(body?JSON.stringify(body):null);
-}
-
-function cancelLaunch(){
-  launchCanceled=true;
-  if(activeXHR){
-    try{activeXHR.abort();}catch(e){}
-    activeXHR=null;
-  }
-  var btn=document.getElementById('btn');
-  var spinner=document.getElementById('spinner');
-  var msg=document.getElementById('msg');
-  btn.disabled=true;
-  var stop=new XMLHttpRequest();
-  stop.open('DELETE','/_api/routes/%[3]s/stop');
-  stop.onload=function(){
-    spinner.style.display='none';
-    msg.style.display='block';
-    msg.style.whiteSpace='normal';msg.style.textAlign='center';msg.style.fontSize='.8rem';
-    msg.textContent='Start canceled';
-    msg.style.color='var(--yellow)';
-    setLaunchMode('retry');
-  };
-  stop.onerror=function(){
-    spinner.style.display='none';
-    msg.style.display='block';
-    msg.textContent='Could not cancel cleanly — safe to retry';
-    msg.style.color='var(--yellow)';
-    setLaunchMode('retry');
-  };
-  stop.send();
-}
-
-function recoverAndRetry(){
-  if(!lastRecovery)return;
-  var rbtn=document.getElementById('recovery-btn');
-  rbtn.disabled=true;
-  // "restart" means: stop the stuck child, then start fresh. Used when the
-  // process is alive but never bound its port — safeKillPID refuses to
-  // signal managed-owned PIDs, so a plain kill_pid won't work here.
-  if(lastRecovery.action==='restart'){
-    var stop=new XMLHttpRequest();
-    stop.open('DELETE','/_api/routes/%[3]s/stop');
-    stop.onload=function(){setTimeout(function(){startApp();},300);};
-    stop.onerror=function(){startApp();};
-    stop.send();
-    return;
-  }
-  // "edit_cmd" rewrites the route's cmd (e.g. python → python3) via PUT,
-  // updates the visible cmd preview, then retries. The cmd field on this
-  // page is server-rendered, so we patch its textContent in-place too.
-  if(lastRecovery.action==='edit_cmd' && lastRecovery.suggested_cmd){
-    var put=new XMLHttpRequest();
-    put.open('PUT','/_api/routes/%[3]s');
-    put.setRequestHeader('Content-Type','application/json');
-    put.onload=function(){
-      if(put.status>=200&&put.status<300){
-        var cmdEl=document.querySelector('.cmd');
-        if(cmdEl)cmdEl.textContent=lastRecovery.suggested_cmd;
-        startApp();
-      }else{
-        rbtn.disabled=false;
-        var em=document.getElementById('msg');
-        em.style.display='block';em.textContent='Failed to update command';em.style.color='var(--red)';
-      }
-    };
-    put.onerror=function(){
-      rbtn.disabled=false;
-      var em=document.getElementById('msg');
-      em.style.display='block';em.textContent='Could not reach daemon';em.style.color='var(--red)';
-    };
-    put.send(JSON.stringify({cmd:lastRecovery.suggested_cmd}));
-    return;
-  }
-  var body={};
-  if(lastRecovery.action==='kill_pid'&&lastRecovery.pid)body.kill_pid=lastRecovery.pid;
-  else if(lastRecovery.action==='kill_port'&&lastRecovery.port)body.kill_port=lastRecovery.port;
-  else return;
-  startApp(body);
-}
-
-// Poll ~35s — slightly longer than waitForReady's 30s deadline so the
-// backend's Failure record is reliably in place when we ask for it.
-function pollUntilReady(attempts){
-  if(launchCanceled){return;}
-  if(attempts>70){
-    // Poll stopped making progress. Ask /ready once more: the backend's
-    // waitForReady writes a Failure (log tail + recovery hint or a
-    // "restart" fallback) when its own deadline expires, so we can show
-    // the tail and a one-click recovery button instead of just "check logs".
-    var msg=document.getElementById('msg');
-    var btn=document.getElementById('btn');
-    var spinner=document.getElementById('spinner');
-    fetchFailureAndRender(0);
-    return;
-  }
-  var xhr=new XMLHttpRequest();
-  xhr.open('GET','/_api/routes/%[3]s/ready');
-  xhr.timeout=2000;
-  xhr.onload=function(){
-    try{
-      var d=JSON.parse(xhr.responseText);
-      if(d.ready){
-        document.getElementById('msg').textContent='Ready';
-        document.getElementById('msg').style.color='var(--green)';
-        setTimeout(function(){window.location.href=window.location.href;},300);
-        return;
-      }
-      if(d.running===false){
-        var msgEl=document.getElementById('msg');
-        msgEl.style.whiteSpace='pre-wrap';msgEl.style.textAlign='left';msgEl.style.fontSize='.75rem';
-        msgEl.textContent=(d.failure&&d.failure.message)?d.failure.message:'Process crashed \u2014 check logs at ~/.vibe/%[3]s.log';
-        msgEl.style.color='var(--red)';
-        setLaunchMode('retry');
-        document.getElementById('spinner').style.display='none';
-        if(d.failure&&d.failure.recovery){showRecovery(d.failure.recovery, d.failure.log||'');}
-        else if(d.failure&&d.failure.log){showFailureLog(d.failure.log);}
-        return;
-      }
-    }catch(e){}
-    setTimeout(function(){pollUntilReady(attempts+1);},500);
-  };
-  xhr.onerror=function(){setTimeout(function(){pollUntilReady(attempts+1);},500);};
-  xhr.ontimeout=function(){setTimeout(function(){pollUntilReady(attempts+1);},500);};
-  xhr.send();
-}
-%[6]s
-startApp();
-</script>
-</body>
-</html>
-`, themeHead(route.Name+"."+tld), themeCSS, safeName, safeTLD, safeCmd, initRecovery)
+	if err := tmplStartPage.Execute(w, data); err != nil {
+		fmt.Fprintf(w, "\n<!-- template error: %v -->\n", err)
+	}
 }
 
 // startPageRecoveryInitJS returns JavaScript that calls showRecovery(...) on

--- a/internal/daemon/templates.go
+++ b/internal/daemon/templates.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+//go:embed templates/*.html.tmpl
+var templateFS embed.FS
+
+var (
+	tmplDashboard  = mustParse("dashboard.html.tmpl")
+	tmplStartPage  = mustParse("startpage.html.tmpl")
+	tmplRepairPage = mustParse("repairpage.html.tmpl")
+)
+
+// templateFuncs are the helpers exposed to all dashboard/startpage/repair templates.
+// iconHTML decides whether to inline an emoji or emit an <img> for data:/http(s)
+// URI icons; both branches return template.HTML so html/template won't double-escape.
+var templateFuncs = template.FuncMap{
+	"iconHTML": iconHTMLFn,
+	"editSVG": func() template.HTML {
+		return template.HTML(`<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z"/></svg>`)
+	},
+}
+
+func mustParse(name string) *template.Template {
+	t, err := template.New(name).Funcs(templateFuncs).ParseFS(templateFS, "templates/"+name)
+	if err != nil {
+		panic(fmt.Sprintf("daemon: parse %s: %v", name, err))
+	}
+	return t
+}
+
+// iconHTMLFn returns the dashboard icon as either a plain (escaped) emoji or
+// an <img> tag for data:/http(s) URIs. The img branch is wrapped in
+// template.HTML so the surrounding template renders it as markup, not text.
+func iconHTMLFn(icon string) template.HTML {
+	if strings.HasPrefix(icon, "data:") || strings.HasPrefix(icon, "http://") || strings.HasPrefix(icon, "https://") {
+		safe := template.HTMLEscapeString(icon)
+		return template.HTML(fmt.Sprintf(`<img src="%s" style="width:100%%;height:100%%;object-fit:contain;border-radius:inherit" onerror="this.style.display='none';this.parentElement.textContent='🔲'">`, safe))
+	}
+	// Emoji or plain text — return escaped, wrapped as HTML so iteration
+	// inside the template doesn't re-escape unicode (a no-op, but keeps
+	// the type signature uniform with the data:/URL branch).
+	return template.HTML(template.HTMLEscapeString(icon))
+}

--- a/internal/daemon/templates/dashboard.html.tmpl
+++ b/internal/daemon/templates/dashboard.html.tmpl
@@ -1,0 +1,634 @@
+{{- /* dashboard.html.tmpl — main dashboard rendered at local.vibe.
+       All user-supplied fields (route names, external URLs, icons, etc.)
+       are auto-escaped by html/template's contextual escaper. */ -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{{.Head}}
+<style>{{.CSS}}
+
+/* Nav bar */
+.navbar{
+  display:flex;align-items:center;justify-content:space-between;
+  padding:0 24px;height:52px;background:var(--surface);
+  border-bottom:1px solid var(--border);position:sticky;top:0;z-index:100;
+}
+.navbar-left{display:flex;align-items:center;gap:16px}
+.brand{font-family:var(--font-display);font-size:1.15rem;color:var(--amber);letter-spacing:.5px;text-decoration:none}
+.status-pill{display:flex;align-items:center;gap:8px;font-size:.78rem;color:var(--text-secondary);letter-spacing:.04em;text-transform:uppercase}
+
+/* Main content */
+.main{max-width:960px;margin:0 auto;padding:28px 24px 60px}
+
+/* Toolbar */
+.toolbar{display:flex;align-items:center;justify-content:space-between;margin-bottom:20px}
+.toolbar-left{display:flex;align-items:baseline;gap:10px}
+.toolbar-title{font-family:var(--font-display);font-size:1.1rem;color:var(--text);letter-spacing:.08em;text-transform:uppercase}
+.toolbar-count{font-size:.78rem;color:var(--text-muted);letter-spacing:.04em}
+.view-toggle{display:flex;background:var(--elevated);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
+.view-toggle button{
+  font-family:var(--font-body);background:none;border:none;
+  color:var(--text-muted);padding:6px 12px;cursor:pointer;
+  display:flex;align-items:center;justify-content:center;transition:background .15s,color .15s;
+}
+.view-toggle button:first-child{border-right:1px solid var(--border)}
+.view-toggle button.active{background:var(--hover);color:var(--amber)}
+.view-toggle button:hover:not(.active){color:var(--text-secondary)}
+.view-toggle svg{width:16px;height:16px}
+
+/* Warning banner */
+.warn{
+  display:flex;align-items:center;gap:8px;
+  padding:12px 16px;margin-bottom:20px;
+  font-size:.82rem;color:var(--yellow);
+  background:rgba(212,168,42,.06);
+  border:1px solid rgba(212,168,42,.2);border-radius:var(--radius);
+}
+
+/* Route table (list view) */
+.list-view{width:100%}
+.route-table{width:100%;border-collapse:collapse}
+.route-table thead th{
+  font-size:.7rem;text-transform:uppercase;letter-spacing:.1em;
+  color:var(--text-muted);font-weight:500;text-align:left;
+  padding:0 12px 10px;border-bottom:1px solid var(--border);
+}
+.route-table tbody tr{border-bottom:1px solid var(--border-subtle);transition:background .1s}
+.route-table tbody tr:hover{background:var(--elevated)}
+.route-table td{padding:11px 12px;vertical-align:middle}
+.route-name-cell{display:flex;align-items:center;gap:10px}
+.route-icon{
+  width:28px;height:28px;border-radius:7px;
+  display:flex;align-items:center;justify-content:center;
+  font-size:15px;line-height:1;flex-shrink:0;
+  background:var(--elevated);border:1px solid var(--border-subtle);
+}
+.route-icon-stopped{opacity:.35}
+.route-name-link{color:var(--text);text-decoration:none;font-weight:600;font-size:.92rem;transition:color .15s}
+.route-name-link:hover{color:var(--amber)}
+.route-url{color:var(--text-muted);font-size:.75rem;margin-left:4px}
+.td-type{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;font-weight:500;color:var(--text-muted)}
+.td-port{font-variant-numeric:tabular-nums;font-size:.85rem}
+.td-port a{color:var(--text-secondary);text-decoration:none;transition:color .15s}
+.td-port a:hover{color:var(--amber)}
+.td-age{color:var(--text-muted);font-size:.8rem}
+.td-actions{display:flex;align-items:center;gap:6px;justify-content:flex-end}
+.td-stopped{opacity:.45}
+.hide-mobile{}
+
+/* Grid view */
+.grid-view{display:none}
+.grid-container{
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(150px,1fr));
+  gap:16px;
+}
+.grid-tile{
+  background:var(--surface);border:1px solid var(--border-subtle);
+  border-radius:var(--radius-lg);padding:20px 12px 16px;
+  display:flex;flex-direction:column;align-items:center;text-align:center;
+  cursor:pointer;transition:background .15s,border-color .15s,box-shadow .2s;
+  position:relative;text-decoration:none;color:var(--text);
+}
+.grid-tile:hover{background:var(--elevated);border-color:var(--border);box-shadow:0 2px 16px rgba(0,0,0,.3)}
+.grid-tile:hover .tile-hover-action{opacity:1}
+.tile-icon{
+  width:64px;height:64px;border-radius:16px;
+  display:flex;align-items:center;justify-content:center;
+  font-size:30px;margin-bottom:10px;
+  background:var(--elevated);border:1px solid var(--border);
+  flex-shrink:0;
+}
+.tile-stopped .tile-icon{opacity:.35}
+.tile-name{font-weight:600;font-size:.88rem;color:var(--text);margin-bottom:3px;letter-spacing:.02em}
+.tile-url{font-size:.7rem;color:var(--text-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
+.tile-hover-action{position:absolute;top:8px;right:8px;opacity:0;transition:opacity .15s}
+.tile-hover-action .btn{font-size:.65rem;padding:3px 8px}
+
+/* Empty state */
+.empty{text-align:center;padding:48px 0;color:var(--text-muted);font-size:.88rem}
+
+/* Get Started section */
+.get-started{
+  margin-top:36px;background:var(--surface);
+  border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;
+}
+.get-started h2{
+  font-family:var(--font-display);font-size:.95rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--amber);margin-bottom:6px;
+}
+.get-started p{font-size:.82rem;color:var(--text-secondary);margin-bottom:14px;line-height:1.5}
+.setup-box{position:relative}
+.setup-textarea{
+  width:100%;font-family:var(--font-body);font-size:.8rem;
+  background:var(--bg);color:var(--text-secondary);
+  border:1px solid var(--border);border-radius:var(--radius);
+  padding:14px;resize:none;line-height:1.6;
+}
+.btn-copy{
+  position:absolute;top:10px;right:10px;
+  font-family:var(--font-body);font-size:.7rem;font-weight:600;
+  text-transform:uppercase;letter-spacing:.06em;
+  background:var(--elevated);color:var(--text-secondary);
+  border:1px solid var(--border);padding:5px 12px;
+  border-radius:var(--radius);cursor:pointer;transition:all .15s;
+}
+.btn-copy:hover{color:var(--text);border-color:var(--text-muted)}
+
+/* Icon picker */
+.icon-picker{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.icon-pick{
+  width:36px;height:36px;border-radius:8px;border:1px solid var(--border);
+  background:var(--bg);display:flex;align-items:center;justify-content:center;
+  font-size:18px;cursor:pointer;transition:all .12s;
+}
+.icon-pick:hover{border-color:var(--amber);background:var(--elevated)}
+.icon-pick.selected{border-color:var(--amber);background:var(--elevated);box-shadow:0 0 8px var(--amber-glow)}
+
+/* Footer */
+.footer{
+  max-width:960px;margin:0 auto;padding:0 24px 32px;
+  display:flex;align-items:center;justify-content:center;
+  gap:20px;font-size:.72rem;color:var(--text-muted);
+}
+.footer a{color:var(--text-muted);text-decoration:none;transition:color .15s}
+.footer a:hover{color:var(--amber)}
+.footer-sep{opacity:.3}
+
+@media(max-width:700px){
+  .navbar{padding:0 16px}
+  .main{padding:20px 16px 48px}
+  .grid-container{grid-template-columns:repeat(auto-fill,minmax(130px,1fr));gap:12px}
+  .hide-mobile{display:none}
+}
+@media(max-width:480px){
+  .grid-container{grid-template-columns:repeat(2,1fr)}
+}
+</style>
+</head>
+<body>
+<nav class="navbar">
+  <div class="navbar-left">
+    <a href="{{.Scheme}}://local.{{.TLD}}/" class="brand">local.vibe</a>
+    <div class="status-pill"><span class="led led-green"></span>Running &middot; {{.Uptime}}</div>
+  </div>
+  <button class="btn-add" onclick="openAddModal()">+ Add Route</button>
+</nav>
+<main class="main">
+{{if .UnknownVisible}}<div class="warn"><span class="led led-yellow"></span>No route for <strong style="color:var(--text);margin:0 4px">{{.UnknownName}}.{{.TLD}}</strong> — register it below.</div>{{end}}
+<div class="toolbar">
+  <div class="toolbar-left">
+    <span class="toolbar-title">Routes</span>
+    <span class="toolbar-count">{{.RouteCount}} active</span>
+  </div>
+  <div class="view-toggle">
+    <button id="btn-list" class="{{.ListBtnClass}}" onclick="setView('list',true)" title="List view">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="1" y1="3" x2="15" y2="3"/><line x1="1" y1="8" x2="15" y2="8"/><line x1="1" y1="13" x2="15" y2="13"/></svg>
+    </button>
+    <button id="btn-grid" class="{{.GridBtnClass}}" onclick="setView('grid',true)" title="Grid view">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="5.5" height="5.5" rx="1"/><rect x="9.5" y="1" width="5.5" height="5.5" rx="1"/><rect x="1" y="9.5" width="5.5" height="5.5" rx="1"/><rect x="9.5" y="9.5" width="5.5" height="5.5" rx="1"/></svg>
+    </button>
+  </div>
+</div>
+<div class="list-view" id="list-view" style="display:{{.ListDisplay}}">
+<table class="route-table">
+<thead><tr>
+  <th style="width:38%">Name</th>
+  <th>Type</th>
+  <th>Port</th>
+  <th class="hide-mobile">Age</th>
+  <th style="text-align:right">Actions</th>
+</tr></thead>
+<tbody>
+<tr>
+  <td><div class="route-name-cell"><span class="route-icon">&#127968;</span><div><a href="{{.Scheme}}://local.{{.TLD}}/" class="route-name-link">local</a><span class="route-url">local.{{.TLD}}</span></div></div></td>
+  <td class="td-type">daemon</td>
+  <td class="td-port"><a href="http://localhost:{{.Port}}" target="_blank">{{.Port}}</a></td>
+  <td class="td-age hide-mobile">{{.Uptime}}</td>
+  <td></td>
+</tr>
+{{range .Routes}}
+<tr>
+  <td><div class="route-name-cell"><span class="{{if .IsStopped}}route-icon route-icon-stopped{{else}}route-icon{{end}}">{{iconHTML .Icon}}</span><div><a href="{{.VibeURL}}" target="_blank" class="route-name-link">{{.Name}}</a><span class="route-url">{{.URLDisplay}}</span></div></div></td>
+  <td class="td-type">{{.Type}}</td>
+  <td class="td-port{{if .IsStopped}} td-stopped{{end}}">{{if eq .Type "bookmark"}}—{{else}}<a href="http://localhost:{{.Port}}" target="_blank">{{.Port}}</a>{{end}}</td>
+  <td class="td-age hide-mobile">{{.Age}}</td>
+  <td><div class="td-actions">
+    {{if and (eq .Type "managed") .IsRunning}}<button class="btn" onclick="routeAction(this,'{{.Name}}','stop')">Stop</button>
+    {{else if eq .Type "managed"}}<button class="btn btn-primary" onclick="routeAction(this,'{{.Name}}','start')">Start</button>{{end}}
+    {{if eq .Type "managed"}}<button class="btn-icon" onclick="openManagedModal('{{.Name}}',{{.Idle}},'{{.UserIcon}}','{{.AutoIcon}}')" title="Settings">{{editSVG}}</button>
+    {{else if eq .Type "sticky"}}<button class="btn-icon" onclick="openEditModal('{{.Name}}',{{.Port}},'{{.ExternalURL}}','local','{{.UserIcon}}','{{.AutoIcon}}',{{.Proxy}},{{.Insecure}})" title="Edit">{{editSVG}}</button>
+    {{else if eq .Type "bookmark"}}<button class="btn-icon" onclick="openEditModal('{{.Name}}',{{.Port}},'{{.ExternalURL}}','bookmark','{{.UserIcon}}','{{.AutoIcon}}',{{.Proxy}},{{.Insecure}})" title="Edit">{{editSVG}}</button>{{end}}
+  </div></td>
+</tr>
+{{end}}
+</tbody></table>
+{{if eq (len .Routes) 0}}<div class="empty">No routes registered yet.</div>{{end}}
+</div>
+
+<div class="grid-view" id="grid-view" style="display:{{.GridDisplay}}"><div class="grid-container">
+<a href="{{.Scheme}}://local.{{.TLD}}/" class="grid-tile">
+  <div class="tile-icon"><span>&#127968;</span></div>
+  <div class="tile-name">local</div>
+  <div class="tile-url">local.{{.TLD}}</div>
+</a>
+{{range .Routes}}
+<a href="{{.VibeURL}}" target="_blank" class="{{if .IsStopped}}grid-tile tile-stopped{{else}}grid-tile{{end}}">
+  <div class="tile-icon">{{iconHTML .Icon}}</div>
+  <div class="tile-name">{{.Name}}</div>
+  <div class="tile-url">{{.URLDisplay}}</div>
+</a>
+{{end}}
+</div></div>
+
+<section class="get-started">
+  <h2>Get Started</h2>
+  <p>Paste this into Claude Code, Cursor, or any agentic IDE to configure a project with local.vibe.</p>
+  <div class="setup-box">
+    <textarea id="setup-text" class="setup-textarea" rows="5" readonly>This machine is running local.vibe, a local DNS tool that gives dev servers friendly .{{.TLD}} names instead of hard-to-remember port numbers.
+
+Read the full setup instructions:
+
+  curl http://localhost:7999/setup.md
+
+Or open in a browser: {{.Scheme}}://local.{{.TLD}}/setup.md</textarea>
+    <button class="btn-copy" id="copy-btn" onclick="copyText()">Copy</button>
+  </div>
+</section>
+</main>
+
+<!-- Add/Edit Modal -->
+<div class="modal-overlay" id="modal-overlay" onclick="if(event.target===this)closeModal()">
+<div class="modal">
+  <div class="modal-header">
+    <button type="button" class="icon-trigger" id="icon-preview" onclick="toggleIconPopover('route-popover',event)" title="Change icon">?</button>
+    <div class="modal-header-text">
+      <div class="modal-eyebrow" id="modal-title">Add Route</div>
+      <h3 id="modal-heading">New route</h3>
+      <div class="modal-sub" id="modal-sub">Map a friendly .vibe name to a local port or external URL.</div>
+    </div>
+  </div>
+  <div class="icon-popover" id="route-popover">
+    <input id="route-icon" type="hidden">
+    <div class="icon-popover-row">
+      <input id="route-icon-custom" type="text" placeholder="Paste any emoji…" oninput="onCustomIcon('route-icon','icon-preview','icon-clear','icon-picker')">
+      <button type="button" class="btn btn-sm" id="icon-clear" onclick="clearIcon('route-icon','icon-preview','icon-clear','icon-picker')" style="display:none">Clear</button>
+    </div>
+    <div class="icon-picker" id="icon-picker"></div>
+  </div>
+  <div class="modal-body">
+    <div class="type-toggle" id="type-toggle">
+      <button id="toggle-local" class="active" onclick="setRouteType('local')">Local Port</button>
+      <button id="toggle-bookmark" onclick="setRouteType('bookmark')">External URL</button>
+    </div>
+    <div class="field-row">
+      <div class="field">
+        <label for="route-name">Name</label>
+        <input id="route-name" type="text" placeholder="myapp" autocomplete="off" oninput="updateModalHeading()">
+      </div>
+      <div id="port-field" class="field field-port">
+        <label for="route-port">Port</label>
+        <input id="route-port" type="number" placeholder="3000">
+      </div>
+    </div>
+    <div id="url-field" class="field" style="display:none">
+      <label for="route-url">URL</label>
+      <input id="route-url" type="text" placeholder="example.com:8080">
+    </div>
+    <div id="options-card" class="options-card" style="display:none">
+      <div id="proxy-field" class="opt">
+        <label class="checkbox-row">
+          <input id="route-proxy" type="checkbox" onchange="onProxyToggle()">
+          <span>Proxy instead of redirect</span>
+        </label>
+        <p class="hint">Keep <code>.vibe</code> in the browser URL. Useful for mirroring Tailscale or intranet hosts on a friendly name.</p>
+      </div>
+      <div id="insecure-field" class="opt" style="display:none">
+        <label class="checkbox-row">
+          <input id="route-insecure" type="checkbox">
+          <span>Allow self-signed TLS cert</span>
+        </label>
+        <p class="hint">Only enable when the upstream uses an untrusted certificate (e.g. Tailscale MagicDNS).</p>
+      </div>
+    </div>
+  </div>
+  <div class="modal-actions">
+    <button class="btn btn-danger" id="modal-delete" style="display:none;margin-right:auto" onclick="deleteRoute()">Delete route</button>
+    <button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn-add" id="modal-save" onclick="saveRoute()">Add</button>
+  </div>
+</div>
+</div>
+<!-- Managed Route Settings Modal -->
+<div class="modal-overlay" id="managed-overlay" onclick="if(event.target===this)closeManagedModal()">
+<div class="modal">
+  <div class="modal-header">
+    <button type="button" class="icon-trigger" id="managed-icon-preview" onclick="toggleIconPopover('managed-popover',event)" title="Change icon">?</button>
+    <div class="modal-header-text">
+      <div class="modal-eyebrow">Managed Route</div>
+      <h3 id="managed-heading">Settings</h3>
+      <div class="modal-sub">Configure a daemon-managed process.</div>
+    </div>
+  </div>
+  <div class="icon-popover" id="managed-popover">
+    <input id="managed-icon" type="hidden">
+    <div class="icon-popover-row">
+      <input id="managed-icon-custom" type="text" placeholder="Paste any emoji…" oninput="onCustomIcon('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker')">
+      <button type="button" class="btn btn-sm" id="managed-icon-clear" onclick="clearIcon('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker')" style="display:none">Clear</button>
+    </div>
+    <div class="icon-picker" id="managed-icon-picker"></div>
+  </div>
+  <div class="modal-body">
+    <div class="field">
+      <label for="managed-name">Name</label>
+      <input id="managed-name" type="text" placeholder="myapp" autocomplete="off" oninput="updateManagedHeading()">
+    </div>
+    <div class="field">
+      <label for="idle-timeout">Auto-stop after idle (minutes)</label>
+      <input id="idle-timeout" type="number" min="0" placeholder="0 = never">
+      <p class="hint">Stop the process automatically when no traffic is received. Set to <code>0</code> to disable.</p>
+    </div>
+  </div>
+  <div class="modal-actions">
+    <button class="btn btn-danger" style="margin-right:auto" onclick="deleteManagedRoute()">Delete route</button>
+    <button class="btn" onclick="closeManagedModal()">Cancel</button>
+    <button class="btn-add" onclick="saveManagedSettings()">Save</button>
+  </div>
+</div>
+</div>
+<script>
+function setView(mode,save){
+  var l=document.getElementById('list-view'),g=document.getElementById('grid-view');
+  var bl=document.getElementById('btn-list'),bg=document.getElementById('btn-grid');
+  if(mode==='grid'){l.style.display='none';g.style.display='block';bl.classList.remove('active');bg.classList.add('active')}
+  else{l.style.display='block';g.style.display='none';bl.classList.add('active');bg.classList.remove('active')}
+  if(save)fetch('/_api/preferences',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({view:mode})});
+}
+
+var modalMode='add';
+var editingName='';
+function setRouteType(t){
+  var modal=document.querySelector('#modal-overlay .modal');
+  var animate=modal&&document.getElementById('modal-overlay').classList.contains('active');
+  var fromH=animate?modal.offsetHeight:0;
+  document.getElementById('toggle-local').className=t==='local'?'active':'';
+  document.getElementById('toggle-bookmark').className=t==='bookmark'?'active':'';
+  document.getElementById('port-field').style.display=t==='local'?'':'none';
+  document.getElementById('url-field').style.display=t==='bookmark'?'':'none';
+  document.getElementById('proxy-field').style.display=t==='bookmark'?'':'none';
+  document.getElementById('options-card').style.display=t==='bookmark'?'':'none';
+  onProxyToggle();
+  if(animate){
+    var toH=modal.offsetHeight;
+    if(toH!==fromH){
+      modal.style.transition='none';
+      modal.style.height=fromH+'px';
+      modal.offsetHeight;
+      modal.style.transition='height .3s cubic-bezier(.4,0,.2,1)';
+      modal.style.height=toH+'px';
+      setTimeout(function(){modal.style.transition='';modal.style.height=''},320);
+    }
+  }
+}
+function onProxyToggle(){
+  var proxyOn=document.getElementById('route-proxy').checked;
+  var bookmark=document.getElementById('toggle-bookmark').className==='active';
+  document.getElementById('insecure-field').style.display=(bookmark&&proxyOn)?'':'none';
+}
+function updateModalHeading(){
+  var n=document.getElementById('route-name').value.trim();
+  document.getElementById('modal-heading').textContent=n?n+'.vibe':(modalMode==='edit'?'Edit route':'New route');
+}
+function updateManagedHeading(){
+  var n=document.getElementById('managed-name').value.trim();
+  document.getElementById('managed-heading').textContent=n?n+'.vibe':'Settings';
+}
+function openAddModal(){
+  modalMode='add';editingName='';
+  document.getElementById('modal-title').textContent='Add Route';
+  document.getElementById('modal-heading').textContent='New route';
+  document.getElementById('modal-sub').textContent='Map a friendly .vibe name to a local port or external URL.';
+  document.getElementById('modal-save').textContent='Add Route';
+  document.getElementById('modal-delete').style.display='none';
+  document.getElementById('type-toggle').style.display='';
+  document.getElementById('route-name').value='';
+  document.getElementById('route-name').disabled=false;
+  document.getElementById('route-port').value='';
+  document.getElementById('route-url').value='';
+  document.getElementById('route-proxy').checked=false;
+  document.getElementById('route-insecure').checked=false;
+  setIconField('route-icon','icon-preview','icon-clear','icon-picker','');
+  setRouteType('local');
+  document.getElementById('modal-overlay').classList.add('active');
+}
+function openEditModal(name,port,url,type,icon,autoIcon,proxy,insecure){
+  modalMode='edit';editingName=name;
+  document.getElementById('modal-title').textContent='Edit Route';
+  document.getElementById('modal-heading').textContent=name+'.vibe';
+  document.getElementById('modal-sub').textContent=type==='bookmark'?'Reverse-proxy or redirect to an external host.':'Forward .vibe traffic to a local port.';
+  document.getElementById('modal-save').textContent='Save';
+  document.getElementById('modal-delete').style.display='';
+  document.getElementById('type-toggle').style.display='';
+  document.getElementById('route-name').value=name;
+  document.getElementById('route-name').disabled=false;
+  document.getElementById('route-icon').dataset.autoicon=autoIcon||'';
+  setIconField('route-icon','icon-preview','icon-clear','icon-picker',icon||'',autoIcon||'');
+  document.getElementById('route-proxy').checked=!!proxy;
+  document.getElementById('route-insecure').checked=!!insecure;
+  if(type==='bookmark'){
+    setRouteType('bookmark');
+    document.getElementById('route-url').value=url;
+    document.getElementById('route-port').value='';
+  }else{
+    setRouteType('local');
+    document.getElementById('route-port').value=port||'';
+    document.getElementById('route-url').value='';
+  }
+  document.getElementById('modal-overlay').classList.add('active');
+}
+function closeModal(){document.getElementById('modal-overlay').classList.remove('active');closeAllIconPopovers()}
+function saveRoute(){
+  var name=document.getElementById('route-name').value.trim();
+  if(!name)return;
+  var isBookmark=document.getElementById('toggle-bookmark').className==='active';
+  var body={name:name,icon:getIconValue('route-icon')};
+  if(isBookmark){
+    var u=document.getElementById('route-url').value.trim();
+    if(!u)return;
+    if(u.indexOf('://')===-1)u='http://'+u;
+    body.url=u;
+    body.proxy=document.getElementById('route-proxy').checked;
+    body.insecure_skip_verify=document.getElementById('route-insecure').checked;
+  }else{
+    var p=parseInt(document.getElementById('route-port').value);
+    if(!p)return;
+    body.port=p;
+    body.proxy=false;
+    body.insecure_skip_verify=false;
+  }
+  if(modalMode==='edit'){
+    fetch('/_api/routes/'+encodeURIComponent(editingName),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(function(){location.reload()});
+  }else{
+    fetch('/_api/routes',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(function(){location.reload()});
+  }
+}
+function deleteRoute(){
+  if(!editingName)return;
+  fetch('/_api/routes/'+encodeURIComponent(editingName),{method:'DELETE',headers:{'Accept':'application/json'}}).then(function(){location.reload()});
+}
+function copyText(){
+  var ta=document.getElementById('setup-text');
+  var btn=document.getElementById('copy-btn');
+  if(navigator.clipboard&&window.isSecureContext){
+    navigator.clipboard.writeText(ta.value).then(function(){
+      btn.textContent='Copied';setTimeout(function(){btn.textContent='Copy'},1500);
+    });
+  }else{
+    ta.select();document.execCommand('copy');window.getSelection().removeAllRanges();
+    btn.textContent='Copied';setTimeout(function(){btn.textContent='Copy'},1500);
+  }
+}
+var managedEditName='';
+function openManagedModal(name,idle,icon,autoIcon){
+  managedEditName=name;
+  document.getElementById('managed-heading').textContent=name+'.vibe';
+  document.getElementById('managed-name').value=name;
+  document.getElementById('idle-timeout').value=idle||'';
+  document.getElementById('managed-icon').dataset.autoicon=autoIcon||'';
+  setIconField('managed-icon','managed-icon-preview','managed-icon-clear','managed-icon-picker',icon||'',autoIcon||'');
+  document.getElementById('managed-overlay').classList.add('active');
+}
+function closeManagedModal(){document.getElementById('managed-overlay').classList.remove('active');closeAllIconPopovers()}
+function deleteManagedRoute(){
+  if(!managedEditName)return;
+  fetch('/_api/routes/'+encodeURIComponent(managedEditName),{method:'DELETE',headers:{'Accept':'application/json'}}).then(function(){location.reload()});
+}
+function saveManagedSettings(){
+  var name=document.getElementById('managed-name').value.trim();
+  if(!name)return;
+  var idle=parseInt(document.getElementById('idle-timeout').value)||0;
+  var body={name:name,idle_timeout:idle,icon:getIconValue('managed-icon')};
+  fetch('/_api/routes/'+encodeURIComponent(managedEditName),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(function(){location.reload()});
+}
+function setIconField(inputId,previewId,clearId,pickerId,val,autoIcon){
+  var inp=document.getElementById(inputId);
+  inp.value=val||'';
+  if(autoIcon!==undefined)inp.dataset.autoicon=autoIcon;
+  var display=val||inp.dataset.autoicon||'';
+  setIconPreviewEl(document.getElementById(previewId),display);
+  document.getElementById(clearId).style.display=val?'':'none';
+  var customInp=document.getElementById(inputId+'-custom');
+  if(customInp&&!val)customInp.value='';
+  highlightPicker(pickerId,val||'');
+}
+function getIconValue(inputId){return document.getElementById(inputId).value}
+function clearIcon(inputId,previewId,clearId,pickerId){
+  var autoIcon=document.getElementById(inputId).dataset.autoicon||'';
+  document.getElementById(inputId+'-custom').value='';
+  setIconField(inputId,previewId,clearId,pickerId,'',autoIcon);
+}
+function onCustomIcon(inputId,previewId,clearId,pickerId){
+  var val=document.getElementById(inputId+'-custom').value.trim();
+  setIconField(inputId,previewId,clearId,pickerId,val);
+}
+var iconChoices=['🚀','🤖','📦','⚡','🔮','🎯','🛠️','💎','🧪','🌐','📡','🎨','🔒','🗂️','📊','🧩'];
+function buildPicker(containerId,inputId,previewId,clearId,popoverId){
+  var c=document.getElementById(containerId);
+  c.innerHTML='';
+  iconChoices.forEach(function(em){
+    var b=document.createElement('button');
+    b.type='button';b.className='icon-pick';b.textContent=em;
+    b.onclick=function(){
+      setIconField(inputId,previewId,clearId,containerId,em);
+      if(popoverId)closeIconPopover(popoverId);
+    };
+    c.appendChild(b);
+  });
+}
+function toggleIconPopover(id,e){
+  if(e){e.stopPropagation()}
+  var p=document.getElementById(id);
+  var wasOpen=p.classList.contains('active');
+  closeAllIconPopovers();
+  if(!wasOpen)p.classList.add('active');
+}
+function closeIconPopover(id){document.getElementById(id).classList.remove('active')}
+function closeAllIconPopovers(){
+  document.querySelectorAll('.icon-popover.active').forEach(function(p){p.classList.remove('active')});
+}
+document.addEventListener('click',function(e){
+  if(e.target.closest('.icon-popover')||e.target.closest('.icon-trigger'))return;
+  closeAllIconPopovers();
+});
+function highlightPicker(containerId,val){
+  var btns=document.getElementById(containerId).querySelectorAll('.icon-pick');
+  btns.forEach(function(b){b.classList.toggle('selected',b.textContent===val)});
+}
+buildPicker('icon-picker','route-icon','icon-preview','icon-clear','route-popover');
+buildPicker('managed-icon-picker','managed-icon','managed-icon-preview','managed-icon-clear','managed-popover');
+
+function setIconPreviewEl(el,val){
+  if(!val){el.textContent='?';el.style.backgroundImage='';return}
+  if(val.startsWith('data:')||val.startsWith('http://')||val.startsWith('https://')){
+    el.textContent='';el.style.backgroundImage='url('+val+')';
+    el.style.backgroundSize='cover';el.style.backgroundPosition='center';
+  }else{
+    el.style.backgroundImage='';el.textContent=val;
+  }
+}
+function routeAction(btn,name,action){
+  var origText=btn.textContent;
+  btn.disabled=true;
+  btn.innerHTML='<span class="spinner"></span>';
+  fetch('/_api/routes/'+encodeURIComponent(name)+'/'+action,{method:'POST',headers:{'Accept':'application/json'}})
+    .then(function(r){
+      if(!r.ok)return r.json().then(function(d){throw new Error(d.error||'Request failed')});
+      return r.json();
+    })
+    .then(function(){
+      if(action==='start'){pollReady(name,0)}
+      else{pollStopped(name,0)}
+    })
+    .catch(function(e){
+      btn.disabled=false;btn.textContent=origText;
+      showToast(e.message||'Action failed');
+    });
+}
+function pollStopped(name,n){
+  if(n>20){location.reload();return}
+  fetch('/_api/routes/'+encodeURIComponent(name)+'/ready')
+    .then(function(r){return r.json()})
+    .then(function(d){
+      if(!d.ready){location.reload()}
+      else{setTimeout(function(){pollStopped(name,n+1)},300)}
+    })
+    .catch(function(){location.reload()});
+}
+function pollReady(name,n){
+  if(n>60){location.reload();return}
+  fetch('/_api/routes/'+encodeURIComponent(name)+'/ready')
+    .then(function(r){return r.json()})
+    .then(function(d){
+      if(d.ready){location.reload()}
+      else if(d.running===false){showToast(name+' crashed during startup');location.reload()}
+      else{setTimeout(function(){pollReady(name,n+1)},500)}
+    })
+    .catch(function(){setTimeout(function(){pollReady(name,n+1)},500)});
+}
+function showToast(msg){
+  var el=document.createElement('div');el.className='toast';el.textContent=msg;
+  document.body.appendChild(el);
+  setTimeout(function(){el.classList.add('show')},10);
+  setTimeout(function(){el.classList.remove('show');setTimeout(function(){el.remove()},300)},4000);
+}
+document.addEventListener('keydown',function(e){if(e.key==='Escape'){closeModal();closeManagedModal()}});
+document.addEventListener('visibilitychange',function(){if(!document.hidden){location.reload()}});
+</script>
+<footer class="footer">
+  <span>daemon :{{.Port}}</span>
+  <span class="footer-sep">|</span>
+  <a href="/_api/routes">API</a>
+  <span class="footer-sep">|</span>
+  <a href="/_api/health">Health</a>
+</footer>
+</body></html>

--- a/internal/daemon/templates/repairpage.html.tmpl
+++ b/internal/daemon/templates/repairpage.html.tmpl
@@ -1,0 +1,147 @@
+{{- /* repairpage.html.tmpl — "reconnecting..." page when a route's port stops answering. */ -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{{.Head}}
+<style>{{.CSS}}
+
+/* Repair page */
+body{display:flex;align-items:center;justify-content:center}
+.card{
+  background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--radius-lg);padding:40px;max-width:440px;width:100%;
+  text-align:center;
+  box-shadow:0 16px 48px rgba(0,0,0,.4);
+  animation:fade-in .2s ease;
+}
+@keyframes fade-in{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}
+h1{font-family:var(--font-display);font-size:1.1rem;font-weight:400;color:var(--yellow);margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em}
+.url{font-size:.85rem;color:var(--text-muted);margin-bottom:8px}
+.status{display:flex;align-items:center;justify-content:center;gap:6px;font-size:.8rem;color:var(--text-muted);margin-bottom:20px;text-transform:uppercase;letter-spacing:.06em}
+.status .led{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--yellow);box-shadow:0 0 8px var(--yellow-glow);animation:pulse 1.2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:.4}50%{opacity:1}}
+.hint{
+  background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);
+  padding:10px 14px;font-family:var(--font-body);font-size:.8rem;color:var(--text-secondary);
+  margin-bottom:20px;text-align:left;line-height:1.5;
+}
+.hint .label{color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-size:.72rem;margin-bottom:4px}
+.hint code{color:var(--amber);font-family:var(--font-body)}
+.page-spinner{
+  display:block;margin:0 auto 14px;width:22px;height:22px;
+  border:1.5px solid #333;border-top-color:var(--yellow);
+  border-radius:50%;animation:spin 1s linear infinite;
+}
+.msg{color:var(--text-muted);font-size:.8rem;margin-top:4px}
+.actions{display:none;flex-direction:column;gap:10px;margin-top:18px}
+.btn{
+  background:var(--amber);color:var(--bg);border:none;border-radius:var(--radius);
+  padding:10px 24px;font-size:.82rem;font-family:var(--font-body);font-weight:600;
+  cursor:pointer;text-transform:uppercase;letter-spacing:.06em;transition:all .15s;
+}
+.btn:hover{background:#f0a048;box-shadow:0 0 12px var(--amber-glow)}
+.btn:disabled{background:var(--surface);color:var(--text-muted);cursor:default;border:1px solid var(--border);box-shadow:none}
+.btn.secondary{background:transparent;border:1px solid var(--border);color:var(--text-secondary)}
+.btn.secondary:hover{border-color:var(--text-secondary);color:var(--text);box-shadow:none;background:var(--elevated)}
+.error{color:var(--red);font-size:.8rem;margin-top:10px;white-space:pre-wrap;text-align:left}
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>{{.Name}}</h1>
+  <div class="url">{{.Name}}.{{.TLD}}</div>
+  <div class="status"><span class="led"></span>Reconnecting</div>
+  <div class="hint">
+    <div class="label">Port {{.Port}} not responding</div>
+    Looking for the app in logs and process listings&hellip;
+  </div>
+  <div class="page-spinner" id="spinner"></div>
+  <div class="msg" id="msg">Probing&hellip;</div>
+  <div class="actions" id="actions"></div>
+  <div class="error" id="error" style="display:none"></div>
+</div>
+<script>
+var attempts=0;
+var maxAttempts=30;
+
+function showActions(html){
+  var box=document.getElementById('actions');
+  box.innerHTML=html;
+  box.style.display='flex';
+}
+
+function giveUp(reason, restartable){
+  document.getElementById('spinner').style.display='none';
+  var msg=document.getElementById('msg');
+  msg.textContent='Could not recover automatically';
+  msg.style.color='var(--red)';
+  var err=document.getElementById('error');
+  err.textContent=reason||'No listening port found nearby.';
+  err.style.display='block';
+  var buttons='';
+  if(restartable){
+    buttons+='<button class="btn" onclick="restartApp()">Restart app</button>';
+  }
+  buttons+='<button class="btn secondary" onclick="window.location.reload()">Retry</button>';
+  buttons+='<a class="btn secondary" href="/" style="text-decoration:none;display:inline-block">Dashboard</a>';
+  showActions(buttons);
+}
+
+function restartApp(){
+  var btns=document.querySelectorAll('#actions .btn');
+  btns.forEach(function(b){b.disabled=true;});
+  document.getElementById('spinner').style.display='block';
+  document.getElementById('msg').style.color='';
+  document.getElementById('msg').textContent='Restarting\u2026';
+  document.getElementById('error').style.display='none';
+  document.getElementById('actions').style.display='none';
+  var xhr=new XMLHttpRequest();
+  xhr.open('POST','/_api/routes/{{.Name}}/start');
+  xhr.setRequestHeader('Accept','application/json');
+  xhr.onload=function(){
+    if(xhr.status===200){
+      attempts=0;
+      setTimeout(pollRepair,500);
+    }else{
+      var err='Failed to start';
+      try{var d=JSON.parse(xhr.responseText);if(d&&d.error)err=d.error;}catch(e){}
+      giveUp(err, true);
+    }
+  };
+  xhr.onerror=function(){giveUp('Could not reach daemon', true);};
+  xhr.send();
+}
+
+function pollRepair(){
+  if(attempts>=maxAttempts){
+    giveUp('Still no listener after '+Math.round(maxAttempts*0.5)+'s. The app may have crashed.', false);
+    return;
+  }
+  attempts++;
+  var xhr=new XMLHttpRequest();
+  xhr.open('GET','/_api/routes/{{.Name}}/repair');
+  xhr.timeout=2500;
+  xhr.onload=function(){
+    var d=null;
+    try{d=JSON.parse(xhr.responseText);}catch(e){}
+    if(d&&d.ok){
+      document.getElementById('msg').textContent='Found it \u2014 reloading';
+      document.getElementById('msg').style.color='var(--green)';
+      setTimeout(function(){window.location.href=window.location.href;},250);
+      return;
+    }
+    if(d&&d.restartable){
+      giveUp(d.reason||'Process is not running.', true);
+      return;
+    }
+    setTimeout(pollRepair,500);
+  };
+  xhr.onerror=function(){setTimeout(pollRepair,500);};
+  xhr.ontimeout=function(){setTimeout(pollRepair,500);};
+  xhr.send();
+}
+
+pollRepair();
+</script>
+</body>
+</html>

--- a/internal/daemon/templates/startpage.html.tmpl
+++ b/internal/daemon/templates/startpage.html.tmpl
@@ -1,0 +1,331 @@
+{{- /* startpage.html.tmpl — "not running" page for stopped managed routes.
+       Auto-escaping covers route name (already validated) and route.Cmd
+       (free-form user input). The {{.RecoveryInit}} block is JSON-marshaled
+       upstream and passed as template.JS so it inlines safely inside <script>. */ -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{{.Head}}
+<style>{{.CSS}}
+
+/* Start page */
+body{display:flex;align-items:center;justify-content:center}
+.card{
+  background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--radius-lg);padding:40px;max-width:420px;width:100%;
+  text-align:center;
+  box-shadow:0 16px 48px rgba(0,0,0,.4);
+  animation:fade-in .2s ease;
+}
+@keyframes fade-in{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}
+h1{font-family:var(--font-display);font-size:1.1rem;font-weight:400;color:var(--amber);margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em}
+.url{font-size:.85rem;color:var(--text-muted);margin-bottom:8px}
+.status{display:flex;align-items:center;justify-content:center;gap:6px;font-size:.8rem;color:var(--text-muted);margin-bottom:24px;text-transform:uppercase;letter-spacing:.06em}
+.cmd{
+  background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);
+  padding:10px 14px;font-family:var(--font-body);font-size:.8rem;color:var(--text-secondary);
+  margin-bottom:24px;text-align:left;word-break:break-all;
+}
+.start-btn{
+  background:var(--amber);color:var(--bg);border:none;border-radius:var(--radius);
+  padding:10px 32px;font-size:.85rem;font-family:var(--font-body);font-weight:600;
+  cursor:pointer;text-transform:uppercase;letter-spacing:.06em;transition:all .15s;
+}
+.start-btn:hover{background:#f0a048;box-shadow:0 0 12px var(--amber-glow)}
+.start-btn:disabled{background:var(--surface);color:var(--text-muted);cursor:default;border:1px solid var(--border);box-shadow:none}
+.page-spinner{
+  display:none;margin:16px auto 0;width:20px;height:20px;
+  border:1.5px solid #333;border-top-color:#888;
+  border-radius:50%;animation:spin .6s linear infinite;
+}
+.msg{color:var(--text-muted);font-size:.8rem;margin-top:10px;display:none}
+.recovery{
+  display:none;margin-top:16px;padding:14px;
+  background:rgba(239,68,68,.06);border:1px solid rgba(239,68,68,.25);
+  border-radius:var(--radius);text-align:left;
+}
+.recovery-msg{font-size:.82rem;color:var(--text-secondary);margin-bottom:10px;line-height:1.4}
+.recovery-btn{
+  background:var(--red,#ef4444);color:#fff;border:none;border-radius:var(--radius);
+  padding:8px 16px;font-size:.78rem;font-family:var(--font-body);font-weight:600;
+  cursor:pointer;text-transform:uppercase;letter-spacing:.06em;transition:all .15s;
+}
+.recovery-btn:hover{filter:brightness(1.1)}
+.recovery-btn:disabled{opacity:.5;cursor:default}
+.log-tail{
+  margin-top:10px;padding:8px;background:var(--bg);border:1px solid var(--border);
+  border-radius:var(--radius);font-family:var(--font-body);font-size:.72rem;
+  color:var(--text-muted);white-space:pre-wrap;max-height:160px;overflow:auto;
+}
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>{{.Name}}</h1>
+  <div class="url">{{.Name}}.{{.TLD}}</div>
+  <div class="status"><span class="led led-red"></span>Stopped</div>
+  <div class="cmd">{{.Cmd}}</div>
+  <button class="start-btn" id="btn" onclick="handlePrimaryButton()">Cancel</button>
+  <div class="page-spinner" id="spinner" style="display:block"></div>
+  <div class="msg" id="msg" style="display:block;color:var(--text-muted)">Launching process…</div>
+  <div class="recovery" id="recovery">
+    <div class="recovery-msg" id="recovery-msg"></div>
+    <button class="recovery-btn" id="recovery-btn" onclick="recoverAndRetry()"></button>
+    <div class="log-tail" id="log-tail" style="display:none"></div>
+  </div>
+</div>
+<script>
+var lastRecovery=null;
+var launchCanceled=false;
+var activeXHR=null;
+var launchMode='cancel'; // cancel | retry
+
+function setLaunchMode(mode){
+  launchMode=mode;
+  var btn=document.getElementById('btn');
+  if(mode==='cancel'){
+    btn.disabled=false;
+    btn.textContent='Cancel';
+    return;
+  }
+  btn.disabled=false;
+  btn.textContent='Retry';
+}
+
+function handlePrimaryButton(){
+  if(launchMode==='cancel'){
+    cancelLaunch();
+    return;
+  }
+  startApp();
+}
+
+function fetchFailureAndRender(tries){
+  var msg=document.getElementById('msg');
+  var spinner=document.getElementById('spinner');
+  var fx=new XMLHttpRequest();
+  fx.open('GET','/_api/routes/{{.Name}}/ready');
+  fx.timeout=2000;
+  fx.onload=function(){
+    var d=null;try{d=JSON.parse(fx.responseText);}catch(e){}
+    if(d&&d.failure){
+      setLaunchMode('retry');spinner.style.display='none';
+      msg.style.whiteSpace='pre-wrap';msg.style.textAlign='left';msg.style.fontSize='.75rem';
+      msg.textContent=d.failure.message||'Server never became ready';
+      msg.style.color='var(--red)';
+      if(d.failure.recovery){showRecovery(d.failure.recovery, d.failure.log||'');}
+      else if(d.failure.log){showFailureLog(d.failure.log);}
+      return;
+    }
+    if(tries<3){setTimeout(function(){fetchFailureAndRender(tries+1);},1000);return;}
+    setLaunchMode('retry');spinner.style.display='none';
+    msg.textContent='Taking too long \u2014 check logs';
+    msg.style.color='var(--yellow)';
+  };
+  fx.onerror=fx.ontimeout=function(){
+    if(tries<3){setTimeout(function(){fetchFailureAndRender(tries+1);},1000);return;}
+    setLaunchMode('retry');spinner.style.display='none';
+    msg.textContent='Taking too long \u2014 check logs';
+    msg.style.color='var(--yellow)';
+  };
+  fx.send();
+}
+
+function hideRecovery(){
+  document.getElementById('recovery').style.display='none';
+  lastRecovery=null;
+}
+
+function showRecovery(rec, logTail){
+  lastRecovery=rec;
+  var box=document.getElementById('recovery');
+  var btn=document.getElementById('recovery-btn');
+  document.getElementById('recovery-msg').textContent=rec.message||'Recoverable error';
+  var logEl=document.getElementById('log-tail');
+  if(rec.action==='info'){
+    btn.style.display='none';
+  }else{
+    btn.style.display='inline-flex';
+    btn.disabled=false;
+    var label='Kill and Retry';
+    if(rec.action==='kill_pid' && rec.pid) label='Kill PID '+rec.pid+' and Retry';
+    else if(rec.action==='kill_port' && rec.port) label='Free Port '+rec.port+' and Retry';
+    else if(rec.action==='restart') label=(rec.pid?'Restart Process (PID '+rec.pid+')':'Restart Process');
+    else if(rec.action==='edit_cmd' && rec.suggested_cmd) label='Use \u0060'+rec.suggested_cmd+'\u0060 and Retry';
+    btn.textContent=label;
+  }
+  if(logTail){logEl.textContent=logTail;logEl.style.display='block';}else{logEl.style.display='none';}
+  box.style.display='block';
+}
+
+function showFailureLog(logTail){
+  lastRecovery=null;
+  var box=document.getElementById('recovery');
+  var btn=document.getElementById('recovery-btn');
+  var logEl=document.getElementById('log-tail');
+  document.getElementById('recovery-msg').textContent='No automatic recovery available. See log tail:';
+  btn.style.display='none';
+  if(logTail){logEl.textContent=logTail;logEl.style.display='block';}else{logEl.style.display='none';}
+  box.style.display='block';
+}
+
+function startApp(body){
+  launchCanceled=false;
+  hideRecovery();
+  var spinner=document.getElementById('spinner');
+  var msg=document.getElementById('msg');
+  setLaunchMode('cancel');
+  spinner.style.display='block';
+  msg.style.display='block';
+  msg.style.color='var(--text-muted)';
+  msg.style.whiteSpace='normal';msg.style.textAlign='center';msg.style.fontSize='.8rem';
+  msg.textContent='Launching process\u2026';
+
+  var xhr=new XMLHttpRequest();
+  activeXHR=xhr;
+  xhr.open('POST','/_api/routes/{{.Name}}/start');
+  xhr.setRequestHeader('Accept','application/json');
+  if(body){xhr.setRequestHeader('Content-Type','application/json');}
+  xhr.onload=function(){
+    activeXHR=null;
+    if(launchCanceled){return;}
+    if(xhr.status===200){
+      msg.textContent='Waiting for server\u2026';
+      pollUntilReady(0);
+    }else{
+      setLaunchMode('retry');
+      spinner.style.display='none';
+      var errMsg='Failed to start';
+      var d=null;
+      try{d=JSON.parse(xhr.responseText);if(d&&d.error)errMsg=d.error;}catch(e){}
+      msg.style.whiteSpace='pre-wrap';msg.style.textAlign='left';msg.style.fontSize='.75rem';
+      msg.textContent=errMsg;
+      msg.style.color='var(--red)';
+      if(d&&d.recovery){showRecovery(d.recovery, d.log||'');}
+      else if(d&&d.log){showFailureLog(d.log);}
+    }
+  };
+  xhr.onerror=function(){
+    activeXHR=null;
+    if(launchCanceled){return;}
+    setLaunchMode('retry');
+    spinner.style.display='none';
+    msg.textContent='Could not reach daemon';
+    msg.style.color='var(--red)';
+  };
+  xhr.send(body?JSON.stringify(body):null);
+}
+
+function cancelLaunch(){
+  launchCanceled=true;
+  if(activeXHR){
+    try{activeXHR.abort();}catch(e){}
+    activeXHR=null;
+  }
+  var btn=document.getElementById('btn');
+  var spinner=document.getElementById('spinner');
+  var msg=document.getElementById('msg');
+  btn.disabled=true;
+  var stop=new XMLHttpRequest();
+  stop.open('DELETE','/_api/routes/{{.Name}}/stop');
+  stop.onload=function(){
+    spinner.style.display='none';
+    msg.style.display='block';
+    msg.style.whiteSpace='normal';msg.style.textAlign='center';msg.style.fontSize='.8rem';
+    msg.textContent='Start canceled';
+    msg.style.color='var(--yellow)';
+    setLaunchMode('retry');
+  };
+  stop.onerror=function(){
+    spinner.style.display='none';
+    msg.style.display='block';
+    msg.textContent='Could not cancel cleanly — safe to retry';
+    msg.style.color='var(--yellow)';
+    setLaunchMode('retry');
+  };
+  stop.send();
+}
+
+function recoverAndRetry(){
+  if(!lastRecovery)return;
+  var rbtn=document.getElementById('recovery-btn');
+  rbtn.disabled=true;
+  if(lastRecovery.action==='restart'){
+    var stop=new XMLHttpRequest();
+    stop.open('DELETE','/_api/routes/{{.Name}}/stop');
+    stop.onload=function(){setTimeout(function(){startApp();},300);};
+    stop.onerror=function(){startApp();};
+    stop.send();
+    return;
+  }
+  if(lastRecovery.action==='edit_cmd' && lastRecovery.suggested_cmd){
+    var put=new XMLHttpRequest();
+    put.open('PUT','/_api/routes/{{.Name}}');
+    put.setRequestHeader('Content-Type','application/json');
+    put.onload=function(){
+      if(put.status>=200&&put.status<300){
+        var cmdEl=document.querySelector('.cmd');
+        if(cmdEl)cmdEl.textContent=lastRecovery.suggested_cmd;
+        startApp();
+      }else{
+        rbtn.disabled=false;
+        var em=document.getElementById('msg');
+        em.style.display='block';em.textContent='Failed to update command';em.style.color='var(--red)';
+      }
+    };
+    put.onerror=function(){
+      rbtn.disabled=false;
+      var em=document.getElementById('msg');
+      em.style.display='block';em.textContent='Could not reach daemon';em.style.color='var(--red)';
+    };
+    put.send(JSON.stringify({cmd:lastRecovery.suggested_cmd}));
+    return;
+  }
+  var body={};
+  if(lastRecovery.action==='kill_pid'&&lastRecovery.pid)body.kill_pid=lastRecovery.pid;
+  else if(lastRecovery.action==='kill_port'&&lastRecovery.port)body.kill_port=lastRecovery.port;
+  else return;
+  startApp(body);
+}
+
+function pollUntilReady(attempts){
+  if(launchCanceled){return;}
+  if(attempts>70){
+    fetchFailureAndRender(0);
+    return;
+  }
+  var xhr=new XMLHttpRequest();
+  xhr.open('GET','/_api/routes/{{.Name}}/ready');
+  xhr.timeout=2000;
+  xhr.onload=function(){
+    try{
+      var d=JSON.parse(xhr.responseText);
+      if(d.ready){
+        document.getElementById('msg').textContent='Ready';
+        document.getElementById('msg').style.color='var(--green)';
+        setTimeout(function(){window.location.href=window.location.href;},300);
+        return;
+      }
+      if(d.running===false){
+        var msgEl=document.getElementById('msg');
+        msgEl.style.whiteSpace='pre-wrap';msgEl.style.textAlign='left';msgEl.style.fontSize='.75rem';
+        msgEl.textContent=(d.failure&&d.failure.message)?d.failure.message:'Process crashed \u2014 check logs at ~/.vibe/{{.Name}}.log';
+        msgEl.style.color='var(--red)';
+        setLaunchMode('retry');
+        document.getElementById('spinner').style.display='none';
+        if(d.failure&&d.failure.recovery){showRecovery(d.failure.recovery, d.failure.log||'');}
+        else if(d.failure&&d.failure.log){showFailureLog(d.failure.log);}
+        return;
+      }
+    }catch(e){}
+    setTimeout(function(){pollUntilReady(attempts+1);},500);
+  };
+  xhr.onerror=function(){setTimeout(function(){pollUntilReady(attempts+1);},500);};
+  xhr.ontimeout=function(){setTimeout(function(){pollUntilReady(attempts+1);},500);};
+  xhr.send();
+}
+{{.RecoveryInit}}
+startApp();
+</script>
+</body>
+</html>

--- a/internal/daemon/theme.go
+++ b/internal/daemon/theme.go
@@ -13,7 +13,7 @@ func themeHead(title string) string {
 }
 
 // themeCSS is the shared base stylesheet — retro-futurist command center design.
-// NOTE: Used inside fmt.Fprintf so literal % must be %.
+// Embedded into html/template via template.CSS(themeCSS), so % is literal.
 const themeCSS = `
 :root{
   --bg:#111113;
@@ -95,7 +95,7 @@ a:hover{color:var(--amber)}
 .led-gray{background:#4a4a52}
 
 /* Modal */
-.modal-overlay{display:none;position:fixed;inset:0;background:rgba(6,6,10,.55);backdrop-filter:blur(14px) saturate(120%);z-index:200;align-items:center;justify-content:center;padding:24px}
+.modal-overlay{display:none;position:fixed;inset:0;background:rgba(6,6,10,.15);backdrop-filter:blur(8px);z-index:200;align-items:center;justify-content:center;padding:24px}
 .modal-overlay.active{display:flex}
 .modal{
   position:relative;


### PR DESCRIPTION
Closes #1

## Summary
- Move inline HTML strings out of `dashboard.go`, `startpage.go`, and `repairpage.go` into embedded `.tmpl` files under `internal/daemon/templates/`
- Add `templates.go` with `embed.FS`, parsed templates, and shared funcMap (`iconHTML`, `editSVG`)
- Lighten the modal overlay backdrop (lower opacity / softer blur)
- Ignore `.claude/` in `.gitignore`

Net diff: `dashboard.go` 892→200, `startpage.go` 392→76, `repairpage.go` 178→37. No behavior changes beyond the modal overlay tweak.

Implements @johngibb's suggestion in #1 — switches the dashboard rendering from `fmt.Fprintf` to `html/template` with auto-escaping, embedded as separate `.tmpl` files via `//go:embed`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] `vibe dev` and visually verify dashboard, start page, and repair page render identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)