### PR TITLE
darwin: fix forkDaemon readiness, pf plist reload, test flake

### DIFF
--- a/cmd/daemon_darwin.go
+++ b/cmd/daemon_darwin.go
@@ -65,9 +65,16 @@ func forkDaemon() error {
 		return fmt.Errorf("failed to start daemon: %w", err)
 	}
 	logFile.Close()
-	for i := 0; i < 10; i++ {
+	// isDaemonRunning flips true as soon as the pidfile lands, which happens
+	// before the HTTP listener is bound. Gate on an actual /_api/health response
+	// so callers don't race the listener.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
 		time.Sleep(200 * time.Millisecond)
-		if isDaemonRunning() {
+		if !isDaemonRunning() {
+			continue
+		}
+		if daemonHTTPResponding() {
 			fmt.Printf("daemon started (pid %d)\n", proc.Process.Pid)
 			fmt.Printf("log: %s\n", logPath)
 			openDashboard()

--- a/cmd/setup_darwin.go
+++ b/cmd/setup_darwin.go
@@ -187,14 +187,15 @@ func installPFLaunchDaemon() error {
 </plist>
 `
 	existing, _ := os.ReadFile(launchDaemonPlist)
-	if string(existing) == plist {
-		// Already installed — reload to apply immediately
-		_ = exec.Command("launchctl", "unload", launchDaemonPlist).Run()
-	} else {
+	if string(existing) != plist {
 		if err := os.WriteFile(launchDaemonPlist, []byte(plist), 0644); err != nil {
 			return fmt.Errorf("write plist: %w", err)
 		}
 	}
+	// launchctl load against an already-loaded label silently no-ops, so any
+	// updated plist content wouldn't activate until reboot. Unload unconditionally
+	// first (ignore error: not-loaded is fine) so the new content takes effect now.
+	_ = exec.Command("launchctl", "unload", launchDaemonPlist).Run()
 	out, err := exec.Command("launchctl", "load", "-w", launchDaemonPlist).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("launchctl load: %w — %s", err, strings.TrimSpace(string(out)))

--- a/internal/daemon/process_test.go
+++ b/internal/daemon/process_test.go
@@ -12,7 +12,10 @@ import (
 )
 
 func TestProcessStartEarlyCrashDetection(t *testing.T) {
-	t.Parallel()
+	// Not t.Parallel: depends on the 1-second early-exit window in
+	// ProcessManager.Start. Under heavy parallel test load the cmd.Wait()
+	// goroutine can miss its scheduling slice and the timer wins, masking
+	// the immediate-exit signal we're asserting on.
 	pm := NewProcessManager()
 
 	route := &Route{


### PR DESCRIPTION
## Summary
- **forkDaemon HTTP readiness** (#15): darwin's `forkDaemon` now polls `daemonHTTPResponding()` with a 5s deadline instead of just `isDaemonRunning()`. The pidfile lands before the HTTP listener is bound, so callers were racing the listener. Matches the Windows path.
- **pf plist reload** (#12): `installPFLaunchDaemon` now always `launchctl unload`s before `load -w`. The old code only unloaded on the identical-content path, so a changed plist silently no-op'd until reboot.
- **Test flake** (#14): drop `t.Parallel()` from `TestProcessStartEarlyCrashDetection` — under heavy parallel load the `cmd.Wait()` goroutine can lose its scheduling slice and the 1s early-exit timer wins, masking the immediate-exit signal under test.

All three are pre-existing — surfaced during the Windows port review.

Issue #13 (ProcessManager.Start narrow-mutex for Windows) is stashed locally; not in this PR — needs Windows testing.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` green
- [x] `go test ./internal/daemon/ -run TestProcess -count=5` green
- [x] `vibe dev` rebuilds and restarts cleanly on darwin
- [ ] CI green on PR

Closes #15
Closes #12
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)